### PR TITLE
Droid4 improvements

### DIFF
--- a/mce-io.h
+++ b/mce-io.h
@@ -41,8 +41,12 @@ typedef void (*iomon_error_cb)(gpointer data, const gchar* device, gconstpointer
 gboolean mce_read_string_from_file(const gchar *const file, gchar **string);
 gboolean mce_read_number_string_from_file(const gchar *const file,
 					  gulong *number);
+gboolean mce_write_string_to_glob(const gchar *const pattern,
+				  const gchar *const string);
 gboolean mce_write_string_to_file(const gchar *const file,
 				  const gchar *const string);
+gboolean mce_write_number_string_to_glob(const gchar *const pattern,
+					 const gulong number);
 gboolean mce_write_number_string_to_file(const gchar *const file,
 					 const gulong number);
 void mce_suspend_io_monitor(gconstpointer io_monitor);

--- a/modules/keypad.c
+++ b/modules/keypad.c
@@ -169,6 +169,12 @@ static void set_n810_backlight_brightness(guint fadetime, guint brightness)
 	(void)mce_write_number_string_to_file(MCE_KEYBOARD_BACKLIGHT_BRIGHTNESS_SYS_PATH, brightness);
 }
 
+static void set_generic_backlight_brightness(guint fadetime, guint brightness)
+{
+	(void)fadetime;
+	(void)mce_write_number_string_to_glob(MCE_KEYBOARD_GENERIC_BACKLIGHT_SYS_PATH, brightness);
+}
+
 static void set_backlight_brightness(gconstpointer data)
 {
 	static gint cached_brightness = -1;
@@ -193,6 +199,7 @@ static void set_backlight_brightness(gconstpointer data)
 		break;
 
 	default:
+		set_generic_backlight_brightness(key_backlight_fadetime, new_brightness);
 		break;
 	}
 

--- a/modules/keypad.h
+++ b/modules/keypad.h
@@ -32,6 +32,8 @@
 #define MCE_KEYBOARD_BACKLIGHT_BRIGHTNESS_SYS_PATH	MCE_KEYBOARD_BACKLIGHT_SYS_PATH "/brightness"
 #define MCE_KEYBOARD_BACKLIGHT_FADETIME_SYS_PATH	MCE_KEYBOARD_BACKLIGHT_SYS_PATH "/time"
 
+#define MCE_KEYBOARD_GENERIC_BACKLIGHT_SYS_PATH	"/sys/class/leds/*::kbd_backlight/brightness"
+
 #include "led.h"
 
 /** Default Lysti backlight LED current */


### PR DESCRIPTION
Can rebase this on top of the other PR by @spinal84 .

This adds support for detecting the Droid 4 by device tree model name, and adds keyboard backlight support. Next up will be proximity sensor, vibration interface (also required for n900), and more, but let's start with this.