### PR TITLE
Add dpms support to display module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ MODULE_CFLAGS := $(COMMON_CFLAGS)
 MODULE_CFLAGS += -fPIC -shared
 MODULE_CFLAGS += -I.
 MODULE_CFLAGS += $$(pkg-config glib-2.0 gmodule-2.0 dbus-1 dbus-glib-1 gconf-2.0 upower-glib --cflags)
-MODULE_LDFLAGS := $$(pkg-config glib-2.0 gmodule-2.0 dbus-1 dbus-glib-1 gconf-2.0 upower-glib libcal --libs)
+MODULE_LDFLAGS := $$(pkg-config glib-2.0 gmodule-2.0 dbus-1 dbus-glib-1 gconf-2.0 upower-glib libcal x11 xext --libs)
 MODULE_LIBS := datapipe.c mce-hal.c mce-log.c mce-dbus.c mce-conf.c mce-gconf.c median_filter.c mce-lib.c
 MODULE_HEADERS := datapipe.h mce-hal.h mce-log.h mce-dbus.h mce-conf.h mce-gconf.h mce.h median_filter.h mce-lib.h
 


### PR DESCRIPTION
This code adds support for DPMS (Display Power Management Signaling) calls in the display module.
Whenever the display would turn brightness all the way off, it will also also force the DPMS mode to off, and whenever the display sets a non-zero display brightness, it will force the DPMS mode to on.

This makes the Droid4 idle to 0.00-0.01A at 4.4V for me, with Maemo Leste booted normally, wifi enabled, and droid4-powermanagement init script installed and run (by default, on boot).

I haven't done extensive testing on other devices, so perhaps we can merge this to `maemo/beowulf-devel` and test it on the N900, Pinephone and VMs.