### PR TITLE
tklock: use X11 to enable and disable the touchscreen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ COMMON_CFLAGS += -DPRG_VERSION=$(VERSION)
 
 MCE_CFLAGS := $(COMMON_CFLAGS)
 MCE_CFLAGS += -DMCE_CONF_FILE=$(CONFDIR)/$(CONFFILE)
-MCE_CFLAGS += $$(pkg-config glib-2.0 gio-2.0 gmodule-2.0 dbus-1 dbus-glib-1 gconf-2.0 osso-systemui-dbus conic --cflags)
-MCE_LDFLAGS := $$(pkg-config glib-2.0 gio-2.0 gmodule-2.0 dbus-1 dbus-glib-1 gconf-2.0 dsme osso-systemui-dbus conic libdevlock1 --libs)
+MCE_CFLAGS += $$(pkg-config glib-2.0 gio-2.0 gmodule-2.0 dbus-1 dbus-glib-1 gconf-2.0 osso-systemui-dbus conic x11 xi --cflags)
+MCE_LDFLAGS := $$(pkg-config glib-2.0 gio-2.0 gmodule-2.0 dbus-1 dbus-glib-1 gconf-2.0 dsme osso-systemui-dbus conic libdevlock1 x11 xi --libs)
 LIBS := devlock.c tklock.c modetransition.c powerkey.c connectivity.c mce-dbus.c mce-dsme.c mce-gconf.c event-input.c event-switches.c mce-hal.c mce-log.c mce-conf.c datapipe.c mce-modules.c mce-io.c mce-lib.c
 HEADERS := devlock.h tklock.h modetransition.h powerkey.h connectivity.h mce.h mce-dbus.h mce-dsme.h mce-gconf.h event-input.h event-switches.h mce-hal.h mce-log.h mce-conf.h datapipe.h mce-modules.h mce-io.h mce-lib.h
 

--- a/tklock.c
+++ b/tklock.c
@@ -28,6 +28,11 @@
 #include <mce/mode-names.h>
 #include <systemui/dbus-names.h>
 #include <systemui/tklock-dbus-names.h>
+
+#include <X11/Xlib.h>
+#include <X11/extensions/XInput.h>
+#include <X11/extensions/XInput2.h>
+
 #include "mce.h"
 #include "tklock.h"
 #include "mce-io.h"
@@ -147,6 +152,11 @@ static inhibit_proximity_relock_t inhibit_proximity_relock = MCE_ALLOW_PROXIMITY
 
 /** TKLock activated due to proximity */
 static gboolean tklock_proximity = FALSE;
+
+static Atom x11_atom_touchscreen = None;
+static Atom x11_atom_device_enabled = None;
+static Atom x11_atom_device_enabled_type = None;
+static int x11_atom_device_enabled_format = 0;
 
 /** Autorelock triggers */
 static gint autorelock_triggers = AUTORELOCK_NO_TRIGGERS;
@@ -295,6 +305,81 @@ EXIT:
 }
 
 /**
+ * Enable/disable X11 input events (currently only for touchscreen)
+ *
+ * @param enable TRUE enable events, FALSE disable events
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean generic_x11_event_control(const gboolean enable)
+{
+	gboolean ret = FALSE;
+	Display* dpy = NULL;
+	XDeviceInfo *devinfo = NULL;
+	int ndev = 0;
+	unsigned char data = (unsigned char)enable;
+
+	dpy = XOpenDisplay(NULL);
+	if (dpy == NULL)
+		dpy = XOpenDisplay(":0.0");
+
+	if (dpy == NULL) {
+		mce_log(LL_INFO, "%s: unable to open display", __func__);
+		return ret;
+	}
+
+	if (x11_atom_touchscreen == None)
+		x11_atom_touchscreen = XInternAtom(dpy, XI_TOUCHSCREEN, True);
+
+	if (x11_atom_device_enabled == None)
+		x11_atom_device_enabled = XInternAtom(dpy, "Device Enabled", False);
+
+	if ((x11_atom_touchscreen == None) || (x11_atom_device_enabled == None)) {
+		mce_log(LL_WARN, "%s: unable to obtain X11 Atoms", __func__);
+		goto done;
+	}
+
+	devinfo = XListInputDevices(dpy, &ndev);
+
+	if (devinfo == NULL)
+		goto done;
+
+	for (int i = 0; i < ndev; i++) {
+		XDeviceInfo info = devinfo[i];
+
+		if (info.use != IsXExtensionPointer)
+			continue;
+		if (info.type != x11_atom_touchscreen)
+			continue;
+
+		if ((x11_atom_device_enabled_type == None) || (x11_atom_device_enabled_format == 0)) {
+			unsigned long ignore_bytes_after, ignore_nitems;
+			unsigned char *ignore_data = NULL;
+
+			if (XIGetProperty(dpy, info.id, x11_atom_device_enabled, 0, 0, False, AnyPropertyType, &x11_atom_device_enabled_type, &x11_atom_device_enabled_format, &ignore_nitems, &ignore_bytes_after, &ignore_data)) {
+				mce_log(LL_WARN, "%s: unable to obtain X11 Device Enabled property atom type", __func__);
+				break;
+			} else {
+				XFree(ignore_data);
+			}
+		}
+
+		XIChangeProperty(dpy, info.id, x11_atom_device_enabled,
+				x11_atom_device_enabled_type,
+				x11_atom_device_enabled_format, PropModeReplace, &data, 1);
+
+		ret = TRUE;
+	}
+
+	XFreeDeviceList(devinfo);
+
+done:
+	if (dpy != NULL)
+		XCloseDisplay(dpy);
+
+	return ret;
+}
+
+/**
  * Enable/disable touchscreen/keypad events
  *
  * @param file Path to enable/disable file
@@ -341,6 +426,9 @@ EXIT:
  */
 static gboolean ts_event_control(gboolean enable)
 {
+	if (generic_x11_event_control(enable))
+		return TRUE;
+
 	return generic_event_control(mce_touchscreen_sysfs_disable_path,
 				     enable);
 }


### PR DESCRIPTION
This will make sure that:

1. We do not get touchscreen input events when the device is locked (and
   not accidentally start/stop programs/apps)
2. X will close the fd X has to the device on disable, so that the
   device can idle (power management wise), once mce also starts to release
   the handle to this device.