### PR TITLE
Add iio-als module to provide ambient light level on a mce datapipe.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ MODULES := \
 	$(MODULE_DIR)/libaccelerometer.so \
 	$(MODULE_DIR)/libcallstate.so \
 	$(MODULE_DIR)/libaudiorouting.so \
-	$(MODULE_DIR)/libhomekey.so
+	$(MODULE_DIR)/libhomekey.so \
+	$(MODULE_DIR)/libiio-als.so
 MODEFILE := mode
 CONFFILE := mce.ini
 DBUSCONF := mce.conf

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ TARGETS := \
 	mce
 MODULES := \
 	$(MODULE_DIR)/libfilter-brightness-als.so \
-	$(MODULE_DIR)/libfilter-brightness-als-iio.so \
 	$(MODULE_DIR)/libfilter-brightness-simple.so \
 	$(MODULE_DIR)/libkeypad.so \
 	$(MODULE_DIR)/libinactivity.so \
@@ -40,8 +39,7 @@ MODULES := \
 	$(MODULE_DIR)/libcallstate.so \
 	$(MODULE_DIR)/libaudiorouting.so \
 	$(MODULE_DIR)/libhomekey.so \
-	$(MODULE_DIR)/libiio-als.so \
-	$(MODULE_DIR)/libbutton-backlight.so
+	$(MODULE_DIR)/libiio-als.so
 MODEFILE := mode
 CONFFILE := mce.ini
 DBUSCONF := mce.conf

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TARGETS := \
 	mce
 MODULES := \
 	$(MODULE_DIR)/libfilter-brightness-als.so \
+	$(MODULE_DIR)/libfilter-brightness-als-iio.so \
 	$(MODULE_DIR)/libfilter-brightness-simple.so \
 	$(MODULE_DIR)/libkeypad.so \
 	$(MODULE_DIR)/libinactivity.so \
@@ -39,7 +40,8 @@ MODULES := \
 	$(MODULE_DIR)/libcallstate.so \
 	$(MODULE_DIR)/libaudiorouting.so \
 	$(MODULE_DIR)/libhomekey.so \
-	$(MODULE_DIR)/libiio-als.so
+	$(MODULE_DIR)/libiio-als.so \
+	$(MODULE_DIR)/libbutton-backlight.so
 MODEFILE := mode
 CONFFILE := mce.ini
 DBUSCONF := mce.conf

--- a/mce.c
+++ b/mce.c
@@ -532,7 +532,7 @@ int main(int argc, char **argv)
 	setup_datapipe(&proximity_sensor_pipe, READ_ONLY, DONT_FREE_CACHE,
 		       0, GINT_TO_POINTER(0));
 	setup_datapipe(&light_sensor_pipe, READ_WRITE, DONT_FREE_CACHE,
-		       0, GUINT_TO_POINTER(0));
+		       0, GINT_TO_POINTER(-1));
 	setup_datapipe(&device_lock_pipe, READ_ONLY, DONT_FREE_CACHE,
 		       0, GINT_TO_POINTER(LOCK_UNDEF));
 	setup_datapipe(&device_lock_inhibit_pipe, READ_ONLY, DONT_FREE_CACHE,

--- a/mce.c
+++ b/mce.c
@@ -531,6 +531,8 @@ int main(int argc, char **argv)
 		       0, GINT_TO_POINTER(0));
 	setup_datapipe(&proximity_sensor_pipe, READ_ONLY, DONT_FREE_CACHE,
 		       0, GINT_TO_POINTER(0));
+	setup_datapipe(&light_sensor_pipe, READ_WRITE, DONT_FREE_CACHE,
+		       0, GUINT_TO_POINTER(0));
 	setup_datapipe(&device_lock_pipe, READ_ONLY, DONT_FREE_CACHE,
 		       0, GINT_TO_POINTER(LOCK_UNDEF));
 	setup_datapipe(&device_lock_inhibit_pipe, READ_ONLY, DONT_FREE_CACHE,

--- a/mce.h
+++ b/mce.h
@@ -292,6 +292,7 @@ datapipe_struct lid_cover_pipe;
 datapipe_struct lens_cover_pipe;
 /** Proximity sensor; read only */
 datapipe_struct proximity_sensor_pipe;
+datapipe_struct light_sensor_pipe;
 /** The alarm UI state */
 datapipe_struct alarm_ui_state_pipe;
 /** The device state */

--- a/mce.h
+++ b/mce.h
@@ -292,6 +292,7 @@ datapipe_struct lid_cover_pipe;
 datapipe_struct lens_cover_pipe;
 /** Proximity sensor; read only */
 datapipe_struct proximity_sensor_pipe;
+/** Ambient light sensor, data in mlux */
 datapipe_struct light_sensor_pipe;
 /** The alarm UI state */
 datapipe_struct alarm_ui_state_pipe;

--- a/mce.ini
+++ b/mce.ini
@@ -503,3 +503,14 @@ PatternPowerKeyPress=5;5;1;1;0;16;0;16;128
 PatternTouchscreen=10;3;0;1;23;0;15;50;255
 PatternChatAndEmail=4;3;1;1;30;360;0;100;154
 PatternUserManual=9;1;0;1;0;0;0;0;0
+
+# If your device provides inaccurate Ambient light sensor data you can callibrate it here.
+# Note this is indicative of a kernel bug please also file a bug report with the relevant maintainer.
+# Procedure:
+# 1. have iio-sensor-proxy installed
+# 2. run monitor-sensor
+# 3. point the device at the sun on a clear day at a time of solar elevation of at least 20 degrees
+# 4. record the lux value and calculate CalScale according to: CalScale = (1.1 * 10^8)/(lux)
+# 5. place the value below and uncomment
+#[IioAls]
+#CalScale = 25

--- a/mce.ini
+++ b/mce.ini
@@ -11,7 +11,7 @@ ModulePath=/usr/lib/mce/modules
 #
 # List of modules to load
 # Note: the name should not include the "lib"-prefix
-Modules=display;keypad;evdevvibrator;led;battery;battery-upower;filter-brightness-als;inactivity;alarm;accelerometer;callstate;camera;homekey;audiorouting
+Modules=display;keypad;evdevvibrator;led;battery;battery-upower;filter-brightness-als;inactivity;alarm;accelerometer;callstate;camera;homekey;audiorouting;iio-als
 
 
 [HomeKey]

--- a/modules/iio-als.c
+++ b/modules/iio-als.c
@@ -26,55 +26,62 @@ G_MODULE_EXPORT module_info_struct module_info = {
 };
 
 static display_state_t display_state = { 0 };
+
 static unsigned int watch_id;
 static GDBusProxy *iio_proxy;
 
-static double iio_als_get_light_value(GDBusProxy *proxy)
+static double iio_als_get_light_value(GDBusProxy * proxy)
 {
 	GVariant *v;
 	GVariant *unit;
 	v = g_dbus_proxy_get_cached_property(iio_proxy, "LightLevel");
 	unit = g_dbus_proxy_get_cached_property(iio_proxy, "LightLevelUnit");
-	/*todo: Handle units other than lux?*/
+	/*todo: Handle units other than lux? */
 	double lux = g_variant_get_double(v);
-	if(lux < 0) lux = 0.0;
-			
-	g_variant_unref (v);
-	g_variant_unref (unit);
-	
+	if (lux < 0)
+		lux = 0.0;
+
+	g_variant_unref(v);
+	g_variant_unref(unit);
+
 	mce_log(LL_DEBUG, "%s: Light level: %lf", MODULE_NAME, lux);
 	return lux;
 }
 
-static bool iio_als_claim_light_sensor(bool claim) {
+static bool iio_als_claim_light_sensor(bool claim)
+{
 	static bool claimed = false;
 	GError *error = NULL;
 	GVariant *ret = NULL;
-	
-	if(iio_proxy)
-	{
+
+	if (iio_proxy) {
 		if (claim && !claimed) {
 			mce_log(LL_DEBUG, "%s: ClaimLight", MODULE_NAME);
-			ret = g_dbus_proxy_call_sync (iio_proxy, "ClaimLight", NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
-			if (!ret && !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
-				mce_log(LL_WARN, "%s: failed to claim ambient light sensor %s", MODULE_NAME, error->message);
-				g_clear_pointer (&ret, g_variant_unref);
+			ret =
+			    g_dbus_proxy_call_sync(iio_proxy, "ClaimLight", NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL,
+						   &error);
+			if (!ret && !g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+				mce_log(LL_WARN, "%s: failed to claim ambient light sensor %s", MODULE_NAME,
+					error->message);
+				g_clear_pointer(&ret, g_variant_unref);
 				return false;
 			}
-			g_clear_pointer (&ret, g_variant_unref);
-			
+			g_clear_pointer(&ret, g_variant_unref);
+
 			int ilux = (int)iio_als_get_light_value(iio_proxy);
 			(void)execute_datapipe(&light_sensor_pipe, GINT_TO_POINTER(ilux), USE_INDATA, CACHE_INDATA);
-		}
-		else if (!claim && claimed) {
+		} else if (!claim && claimed) {
 			mce_log(LL_DEBUG, "%s: ReleaseLight", MODULE_NAME);
-			ret = g_dbus_proxy_call_sync (iio_proxy, "ReleaseLight", NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
-			if (!ret && !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
-				mce_log(LL_WARN, "%s: failed to relese ambient light sensor %s", MODULE_NAME, error->message);
-				g_clear_pointer (&ret, g_variant_unref);
+			ret =
+			    g_dbus_proxy_call_sync(iio_proxy, "ReleaseLight", NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL,
+						   &error);
+			if (!ret && !g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+				mce_log(LL_WARN, "%s: failed to relese ambient light sensor %s", MODULE_NAME,
+					error->message);
+				g_clear_pointer(&ret, g_variant_unref);
 				return false;
 			}
-			g_clear_pointer (&ret, g_variant_unref);
+			g_clear_pointer(&ret, g_variant_unref);
 		}
 		claimed = claim;
 	}
@@ -88,27 +95,26 @@ static void display_state_trigger(gconstpointer data)
 	iio_als_claim_light_sensor(display_state == MCE_DISPLAY_ON);
 }
 
-static void iio_als_properties_changed (GDBusProxy *proxy,
-		    GVariant   *changed_properties,
-		    GStrv       invalidated_properties,
-		    gpointer    user_data)
+static void iio_als_properties_changed(GDBusProxy * proxy,
+				       GVariant * changed_properties, GStrv invalidated_properties, gpointer user_data)
 {
-	
+
 	GVariantDict dict;
 
-	g_variant_dict_init (&dict, changed_properties);
+	g_variant_dict_init(&dict, changed_properties);
 
-	if (g_variant_dict_contains (&dict, "LightLevel")) {
+	if (g_variant_dict_contains(&dict, "LightLevel")) {
 
 		int ilux = (int)iio_als_get_light_value(iio_proxy);
 		(void)execute_datapipe(&light_sensor_pipe, GINT_TO_POINTER(ilux), USE_INDATA, CACHE_INDATA);
-		
+
 	}
 
-	g_variant_dict_clear (&dict);
+	g_variant_dict_clear(&dict);
 }
 
-static void iio_als_sensors_appeared (GDBusConnection *connection, const gchar *name, const gchar *name_owner, gpointer user_data)
+static void iio_als_sensors_appeared(GDBusConnection * connection, const gchar * name, const gchar * name_owner,
+				     gpointer user_data)
 {
 	GError *error = NULL;
 	GVariant *ret = NULL;
@@ -119,29 +125,25 @@ static void iio_als_sensors_appeared (GDBusConnection *connection, const gchar *
 
 	mce_log(LL_INFO, "%s: Found iio_sensor_proxy", MODULE_NAME);
 
-	iio_proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
-						   G_DBUS_PROXY_FLAGS_NONE,
-						   NULL,
-						   "net.hadess.SensorProxy",
-						   "/net/hadess/SensorProxy",
-						   "net.hadess.SensorProxy",
-						   NULL, NULL);
+	iio_proxy = g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SYSTEM,
+						  G_DBUS_PROXY_FLAGS_NONE,
+						  NULL,
+						  "net.hadess.SensorProxy",
+						  "/net/hadess/SensorProxy", "net.hadess.SensorProxy", NULL, NULL);
 
-	g_signal_connect (G_OBJECT (iio_proxy), "g-properties-changed", G_CALLBACK (iio_als_properties_changed), NULL);
-	
+	g_signal_connect(G_OBJECT(iio_proxy), "g-properties-changed", G_CALLBACK(iio_als_properties_changed), NULL);
+
 	if (display_state == MCE_DISPLAY_ON)
 		iio_als_claim_light_sensor(true);
 }
 
-static void iio_als_sensors_vanished (GDBusConnection *connection,
-	     const gchar *name,
-	     gpointer user_data)
+static void iio_als_sensors_vanished(GDBusConnection * connection, const gchar * name, gpointer user_data)
 {
 	(void)name;
 	(void)user_data;
 	(void)connection;
 	if (iio_proxy) {
-		g_clear_object (&iio_proxy);
+		g_clear_object(&iio_proxy);
 		iio_proxy = NULL;
 		mce_log(LL_WARN, "%s: connection to iio_sensor_proxy lost", MODULE_NAME);
 	}
@@ -154,16 +156,13 @@ const char *g_module_check_init(GModule * module)
 
 	mce_log(LL_DEBUG, "Initalizing %s", MODULE_NAME);
 
-	append_output_trigger_to_datapipe(&display_state_pipe,
-					  display_state_trigger);
+	append_output_trigger_to_datapipe(&display_state_pipe, display_state_trigger);
 
 	display_state = datapipe_get_gint(display_state_pipe);
-	
-	watch_id = g_bus_watch_name (G_BUS_TYPE_SYSTEM, "net.hadess.SensorProxy",
-					G_BUS_NAME_WATCHER_FLAGS_NONE,
-					iio_als_sensors_appeared,
-					iio_als_sensors_vanished,
-					NULL, NULL);
+
+	watch_id = g_bus_watch_name(G_BUS_TYPE_SYSTEM, "net.hadess.SensorProxy",
+				    G_BUS_NAME_WATCHER_FLAGS_NONE,
+				    iio_als_sensors_appeared, iio_als_sensors_vanished, NULL, NULL);
 
 	return NULL;
 }
@@ -173,7 +172,6 @@ void g_module_unload(GModule * module)
 {
 	(void)module;
 
-	remove_output_trigger_from_datapipe(&display_state_pipe,
-					    display_state_trigger);
+	remove_output_trigger_from_datapipe(&display_state_pipe, display_state_trigger);
 
 }

--- a/modules/iio-als.c
+++ b/modules/iio-als.c
@@ -90,7 +90,7 @@ static void iio_als_properties_changed (GDBusProxy *proxy,
 		unsigned int uilux = (unsigned int)lux;
 		
 		mce_log(LL_DEBUG, "%s: Light level: %u", MODULE_NAME, uilux);
-		(void)execute_datapipe(&light_sensor_pipe, GUINT_TO_POINTER(uilux), USE_INDATA, CACHE_INDATA);
+		(void)execute_datapipe(&light_sensor_pipe, GINT_TO_POINTER(uilux), USE_INDATA, CACHE_INDATA);
 		
 		g_variant_unref (v);
 		g_variant_unref (unit);

--- a/modules/iio-als.c
+++ b/modules/iio-als.c
@@ -1,0 +1,169 @@
+#include <glib.h>
+#include <gio/gio.h>
+#include <gmodule.h>
+#include <glib/gstdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include "mce.h"
+#include "mce-io.h"
+#include "mce-hal.h"
+#include "mce-log.h"
+#include "mce-conf.h"
+#include "mce-dbus.h"
+#include "datapipe.h"
+
+#define MODULE_NAME		"iio-als"
+
+#define MODULE_PROVIDES	"als"
+
+static const char *const provides[] = { MODULE_PROVIDES, NULL };
+
+G_MODULE_EXPORT module_info_struct module_info = {
+	.name = MODULE_NAME,
+	.provides = provides,
+	.priority = 100
+};
+
+static display_state_t display_state = { 0 };
+static unsigned int watch_id;
+static GDBusProxy *iio_proxy;
+
+
+static bool iio_als_claim_light_sensor(bool claim) {
+	static bool claimed = false;
+	GError *error = NULL;
+	GVariant *ret = NULL;
+	
+	if(iio_proxy)
+	{
+		if (claim && !claimed) {
+			mce_log(LL_DEBUG, "%s: ClaimLight", MODULE_NAME);
+			ret = g_dbus_proxy_call_sync (iio_proxy, "ClaimLight", NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+			if (!ret && !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+				mce_log(LL_WARN, "%s: failed to claim ambient light sensor %s", MODULE_NAME, error->message);
+				g_clear_pointer (&ret, g_variant_unref);
+				return false;
+			}
+			g_clear_pointer (&ret, g_variant_unref);
+		}
+		else if (!claim && claimed) {
+			mce_log(LL_DEBUG, "%s: ReleaseLight", MODULE_NAME);
+			ret = g_dbus_proxy_call_sync (iio_proxy, "ReleaseLight", NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+			if (!ret && !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+				mce_log(LL_WARN, "%s: failed to relese ambient light sensor %s", MODULE_NAME, error->message);
+				g_clear_pointer (&ret, g_variant_unref);
+				return false;
+			}
+			g_clear_pointer (&ret, g_variant_unref);
+		}
+		claimed = claim;
+	}
+	return true;
+}
+
+static void display_state_trigger(gconstpointer data)
+{
+	(void)data;
+	display_state = datapipe_get_gint(display_state_pipe);
+	iio_als_claim_light_sensor(display_state == MCE_DISPLAY_ON);
+}
+
+static void iio_als_properties_changed (GDBusProxy *proxy,
+		    GVariant   *changed_properties,
+		    GStrv       invalidated_properties,
+		    gpointer    user_data)
+{
+	GVariant *v;
+	GVariantDict dict;
+
+	g_variant_dict_init (&dict, changed_properties);
+
+	if (g_variant_dict_contains (&dict, "LightLevel")) {
+		GVariant *unit;
+
+		v = g_dbus_proxy_get_cached_property (iio_proxy, "LightLevel");
+		unit = g_dbus_proxy_get_cached_property (iio_proxy, "LightLevelUnit");
+		/*todo: Handle units other than lux?*/
+		double lux = g_variant_get_double (v);
+		if(lux < 0) lux = 0;
+		unsigned int uilux = (unsigned int)lux;
+		
+		mce_log(LL_DEBUG, "%s: Light level: %u", MODULE_NAME, uilux);
+		(void)execute_datapipe(&light_sensor_pipe, GUINT_TO_POINTER(uilux), USE_INDATA, CACHE_INDATA);
+		
+		g_variant_unref (v);
+		g_variant_unref (unit);
+	}
+
+	g_variant_dict_clear (&dict);
+}
+
+static void iio_als_sensors_appeared (GDBusConnection *connection, const gchar *name, const gchar *name_owner, gpointer user_data)
+{
+	GError *error = NULL;
+	GVariant *ret = NULL;
+	(void)name;
+	(void)name_owner;
+	(void)connection;
+	(void)user_data;
+
+	mce_log(LL_INFO, "%s: Found iio_sensor_proxy", MODULE_NAME);
+
+	iio_proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
+						   G_DBUS_PROXY_FLAGS_NONE,
+						   NULL,
+						   "net.hadess.SensorProxy",
+						   "/net/hadess/SensorProxy",
+						   "net.hadess.SensorProxy",
+						   NULL, NULL);
+
+	g_signal_connect (G_OBJECT (iio_proxy), "g-properties-changed", G_CALLBACK (iio_als_properties_changed), NULL);
+	
+	if (display_state == MCE_DISPLAY_ON)
+		iio_als_claim_light_sensor(true);
+}
+
+static void iio_als_sensors_vanished (GDBusConnection *connection,
+	     const gchar *name,
+	     gpointer user_data)
+{
+	(void)name;
+	(void)user_data;
+	if (iio_proxy) {
+		g_clear_object (&iio_proxy);
+		iio_proxy = NULL;
+		mce_log(LL_WARN, "%s: connection to iio_sensor_proxy lost", MODULE_NAME);
+	}
+}
+
+G_MODULE_EXPORT const char *g_module_check_init(GModule * module);
+const char *g_module_check_init(GModule * module)
+{
+	(void)module;
+
+	mce_log(LL_DEBUG, "Initalizing %s", MODULE_NAME);
+
+	append_output_trigger_to_datapipe(&display_state_pipe,
+					  display_state_trigger);
+
+	display_state = datapipe_get_gint(display_state_pipe);
+	
+	watch_id = g_bus_watch_name (G_BUS_TYPE_SYSTEM, "net.hadess.SensorProxy",
+					G_BUS_NAME_WATCHER_FLAGS_NONE,
+					iio_als_sensors_appeared,
+					iio_als_sensors_vanished,
+					NULL, NULL);
+
+	return NULL;
+}
+
+G_MODULE_EXPORT void g_module_unload(GModule * module);
+void g_module_unload(GModule * module)
+{
+	(void)module;
+
+	remove_output_trigger_from_datapipe(&display_state_pipe,
+					    display_state_trigger);
+
+}


### PR DESCRIPTION
this module uses iio-sensor-proxy to provide mce with als values on an mce datapipe on any device with an iio als sensor.
this data not used right now by filter-brightness-als.

the intention is to split filter-brightness-als into three different modules: 

1. Als data input (provided by this module)
2. A brightness filter that uses the als data to set brightness
3. A module that deals with button backlights and sets button backlight brightness based on als data.


and do it in a way that requires no device specific code and minimal device specific configuration.

