### PR TITLE
Display inactivity refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,12 @@ MODULES := \
 	$(MODULE_DIR)/libfilter-brightness-simple.so \
 	$(MODULE_DIR)/libkeypad.so \
 	$(MODULE_DIR)/libinactivity.so \
+	$(MODULE_DIR)/libinactivity-dev.so \
 	$(MODULE_DIR)/libcamera.so \
 	$(MODULE_DIR)/libalarm.so \
 	$(MODULE_DIR)/libbattery-upower.so \
 	$(MODULE_DIR)/libdisplay.so \
+	$(MODULE_DIR)/libdisplay-dev.so \
 	$(MODULE_DIR)/libled.so \
 	$(MODULE_DIR)/libvibrator.so \
 	$(MODULE_DIR)/libevdevvibrator.so \

--- a/modules/display-dev.c
+++ b/modules/display-dev.c
@@ -1,0 +1,890 @@
+/**
+ * @file display.c
+ * Display module -- this implements display handling for MCE
+ * <p>
+ * Copyright © 2007-2010 Nokia Corporation and/or its subsidiary(-ies).
+ * <p>
+ * @author David Weinehall <david.weinehall@nokia.com>
+ * @author Jonathan Wilson <jfwfreo@tpgi.com.au>
+ *
+ * mce is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * mce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mce.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <glib.h>
+#include <gmodule.h>
+#include <glib/gstdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <linux/fb.h>
+#include <sys/ioctl.h>
+#include <mce/mode-names.h>
+#include "mce.h"
+#include "display-dev.h"
+#include "mce-io.h"
+#include "mce-lib.h"
+#include "mce-log.h"
+#include "mce-dbus.h"
+#include "mce-gconf.h"
+#include "datapipe.h"
+#include "x11-utils.h"
+
+/** Module name */
+#define MODULE_NAME		"display-dev"
+
+/** Functionality provided by this module */
+static const gchar *const provides[] = { MODULE_NAME, NULL };
+
+/** Module information */
+G_MODULE_EXPORT module_info_struct module_info = {
+	/** Name of the module */
+	.name = MODULE_NAME,
+	/** Module provides */
+	.provides = provides,
+	/** Module priority */
+	.priority = 250
+};
+
+/** GConf callback ID for display brightness setting */
+static guint disp_brightness_gconf_cb_id = 0;
+
+/** Display blanking timeout setting */
+static gint disp_blank_timeout = DEFAULT_BLANK_TIMEOUT;
+/** GConf callback ID for display blanking timeout setting */
+static guint disp_blank_timeout_gconf_cb_id = 0;
+
+/** Cached brightness */
+static gint cached_brightness = -1;
+
+/** Target brightness */
+static gint target_brightness = -1;
+
+static gint set_brightness = -1;
+
+/** Fadeout step length */
+static gint brightness_fade_steplength = 2;
+
+/** Brightness fade timeout callback ID */
+static gint brightness_fade_timeout_cb_id = 0;
+/** Display blanking timeout callback ID */
+static gint blank_timeout_cb_id = 0;
+
+/** Maximum display brightness */
+static gint maximum_display_brightness = DEFAULT_MAXIMUM_DISPLAY_BRIGHTNESS;
+
+static gchar *brightness_file = NULL;
+static gchar *max_brightness_file = NULL;
+static gboolean hw_display_fading = FALSE;
+
+static gboolean is_tvout_state_changed = FALSE;
+
+
+/**
+ * Call the FBIOBLANK ioctl
+ *
+ * @param value The ioctl value to pass to the backlight
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean backlight_ioctl(int value)
+{
+	static int old_value = FB_BLANK_UNBLANK;
+	static int fd = -1;
+	gboolean status = FALSE;
+
+	if (fd == -1) {
+		if ((fd = open(FB_DEVICE, O_RDWR)) == -1) {
+			mce_log(LL_CRIT, "cannot open `%s'", FB_DEVICE);
+			goto EXIT;
+		}
+
+		old_value = !value; /* force ioctl() */
+	}
+
+	if (value != old_value) {
+		if (ioctl(fd, FBIOBLANK, value) == -1) {
+			mce_log(LL_CRIT,
+				"ioctl() FBIOBLANK (%d) failed on `%s'; %s",
+				value, FB_DEVICE, g_strerror(errno));
+			close(fd);
+			fd = -1;
+
+			/* Reset errno,
+			 * to avoid false positives down the line
+			 */
+			errno = 0;
+
+			goto EXIT;
+		}
+
+		old_value = value;
+	}
+
+	status = TRUE;
+
+EXIT:
+	return status;
+}
+
+/**
+ * Timeout callback for the brightness fade
+ *
+ * @param data Unused
+ * @return Returns TRUE to repeat, until the cached brightness has reached
+ *         the destination value; when this happens, FALSE is returned
+ */
+static gboolean brightness_fade_timeout_cb(gpointer data)
+{
+	gboolean retval = TRUE;
+
+	(void)data;
+
+	if ((cached_brightness <= 0) && (target_brightness != 0)) {
+		backlight_ioctl(FB_BLANK_UNBLANK);
+		x11_force_dpms_display_level(TRUE);
+	}
+
+	if ((cached_brightness == -1) ||
+	    (ABS(cached_brightness -
+		 target_brightness) < brightness_fade_steplength)) {
+		cached_brightness = target_brightness;
+		retval = FALSE;
+	} else if (target_brightness > cached_brightness) {
+		cached_brightness += brightness_fade_steplength;
+	} else {
+		cached_brightness -= brightness_fade_steplength;
+	}
+
+	mce_write_number_string_to_file(brightness_file,
+					cached_brightness);
+
+	if (cached_brightness == 0) {
+		backlight_ioctl(FB_BLANK_POWERDOWN);
+		x11_force_dpms_display_level(FALSE);
+	}
+
+	if (retval == FALSE)
+		 brightness_fade_timeout_cb_id = 0;
+
+	return retval;
+}
+
+/**
+ * Cancel the brightness fade timeout
+ */
+static void cancel_brightness_fade_timeout(void)
+{
+	/* Remove the timeout source for the display brightness fade */
+	if (brightness_fade_timeout_cb_id != 0) {
+		g_source_remove(brightness_fade_timeout_cb_id);
+		brightness_fade_timeout_cb_id = 0;
+	}
+}
+
+/**
+ * Setup the brightness fade timeout
+ *
+ * @param step_time The time between each brightness step
+ */
+static void setup_brightness_fade_timeout(gint step_time)
+{
+	cancel_brightness_fade_timeout();
+
+	/* Setup new timeout */
+	brightness_fade_timeout_cb_id =
+		g_timeout_add(step_time, brightness_fade_timeout_cb, NULL);
+}
+
+/**
+ * Update brightness fade
+ *
+ * Will fade from current value to new value
+ *
+ * @param new_brightness The new brightness to fade to
+ */
+static void update_brightness_fade(gint new_brightness)
+{
+	gint step_time = 10;
+
+	if (hw_display_fading == TRUE) {
+		cancel_brightness_fade_timeout();
+		cached_brightness = new_brightness;
+		target_brightness = new_brightness;
+		backlight_ioctl(FB_BLANK_UNBLANK);
+		mce_write_number_string_to_file(brightness_file,
+						new_brightness);
+		goto EXIT;
+	}
+
+	/* If we're already fading towards the right brightness,
+	 * don't change anything
+	 */
+	if (target_brightness == new_brightness)
+		goto EXIT;
+
+	target_brightness = new_brightness;
+
+	brightness_fade_steplength = 2;
+
+	setup_brightness_fade_timeout(step_time);
+
+EXIT:
+	return;
+}
+
+/**
+ * Blank display
+ */
+static void display_blank(void)
+{
+	cancel_brightness_fade_timeout();
+	cached_brightness = 0;
+	target_brightness = 0;
+	mce_write_number_string_to_file(brightness_file, 0);
+	backlight_ioctl(FB_BLANK_POWERDOWN);
+	x11_force_dpms_display_level(FALSE);
+}
+
+/**
+ * Dim display
+ */
+static void display_dim(void)
+{
+	if (cached_brightness == 0) {
+		backlight_ioctl(FB_BLANK_UNBLANK);
+		x11_force_dpms_display_level(TRUE);
+	}
+
+	update_brightness_fade((maximum_display_brightness *
+			        DEFAULT_DIM_BRIGHTNESS) / 100);
+}
+
+/**
+ * Unblank display
+ */
+static void display_unblank(void)
+{
+	/* If we unblank, switch on display immediately */
+	if (cached_brightness == 0) {
+		cached_brightness = set_brightness;
+		target_brightness = set_brightness;
+		backlight_ioctl(FB_BLANK_UNBLANK);
+		mce_write_number_string_to_file(brightness_file,
+						set_brightness);
+		x11_force_dpms_display_level(TRUE);
+	} else {
+		update_brightness_fade(set_brightness);
+	}
+}
+
+/**
+ * Display brightness trigger
+ *
+ * @note A brightness request is only sent if the value changed
+ * @param data The display brightness stored in a pointer
+ */
+static void display_brightness_trigger(gconstpointer data)
+{
+	display_state_t display_state = datapipe_get_gint(display_state_pipe);
+	gint new_brightness = GPOINTER_TO_INT(data);
+
+	/* If the pipe is choked, ignore the value */
+	if (new_brightness == 0)
+		goto EXIT;
+
+	/* Adjust the value, since it's a percentage value */
+	new_brightness = (maximum_display_brightness * new_brightness) / 100;
+
+	/* If we're just rehashing the same brightness value, don't bother */
+	if ((new_brightness == cached_brightness) && (cached_brightness != -1))
+		goto EXIT;
+
+	/* The value we have here is for non-dimmed screen only */
+	set_brightness = new_brightness;
+
+	if ((display_state == MCE_DISPLAY_OFF) ||
+	    (display_state == MCE_DISPLAY_DIM))
+		goto EXIT;
+
+	update_brightness_fade(new_brightness);
+
+EXIT:
+	return;
+}
+
+/**
+ * Timeout callback for display blanking
+ *
+ * @param data Unused
+ * @return Always returns FALSE, to disable the timeout
+ */
+static gboolean blank_timeout_cb(gpointer data)
+{
+	(void)data;
+
+	blank_timeout_cb_id = 0;
+
+	(void)execute_datapipe(&display_state_pipe,
+			       GINT_TO_POINTER(MCE_DISPLAY_OFF),
+			       USE_INDATA, CACHE_INDATA);
+
+	return FALSE;
+}
+
+/**
+ * Cancel the display blanking timeout
+ */
+static void cancel_blank_timeout(void)
+{
+	/* Remove the timeout source for display blanking */
+	if (blank_timeout_cb_id != 0) {
+		g_source_remove(blank_timeout_cb_id);
+		blank_timeout_cb_id = 0;
+	}
+}
+
+/**
+ * Setup blank timeout
+ */
+static void setup_blank_timeout(void)
+{
+	cancel_blank_timeout();
+
+	/* Setup new timeout */
+	blank_timeout_cb_id =
+		g_timeout_add_seconds(disp_blank_timeout,
+				      blank_timeout_cb, NULL);
+}
+
+/**
+ * GConf callback for display related settings
+ *
+ * @param gcc Unused
+ * @param id Connection ID from gconf_client_notify_add()
+ * @param entry The modified GConf entry
+ * @param data Unused
+ */
+static void display_gconf_cb(GConfClient *const gcc, const guint id,
+			     GConfEntry *const entry, gpointer const data)
+{
+	GConfValue *gcv = gconf_entry_get_value(entry);
+
+	(void)gcc;
+	(void)data;
+
+	/* Key is unset */
+	if (gcv == NULL) {
+		mce_log(LL_DEBUG,
+			"GConf Key `%s' has been unset",
+			gconf_entry_get_key(entry));
+		goto EXIT;
+	}
+
+	if (id == disp_brightness_gconf_cb_id) {
+		gint tmp = gconf_value_get_int(gcv);
+
+		(void)execute_datapipe(&display_brightness_pipe,
+				       GINT_TO_POINTER(tmp),
+				       USE_INDATA, CACHE_INDATA);
+	} else if (id == disp_blank_timeout_gconf_cb_id) {
+		disp_blank_timeout = gconf_value_get_int(gcv);
+	} else {
+		mce_log(LL_WARN,
+			"Spurious GConf value received; confused!");
+	}
+
+EXIT:
+	return;
+}
+
+/**
+ * Send a display status reply or signal
+ *
+ * @param method_call A DBusMessage to reply to;
+ *                    pass NULL to send a display status signal instead
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean send_display_status(DBusMessage *const method_call)
+{
+	display_state_t display_state = datapipe_get_gint(display_state_pipe);
+	gboolean is_tvout_on = datapipe_get_gint(tvout_pipe);
+
+	DBusMessage *msg = NULL;
+	const gchar *state = NULL;
+	gboolean status = FALSE;
+
+	switch (display_state) {
+	case MCE_DISPLAY_OFF:
+		state = MCE_DISPLAY_OFF_STRING;
+		break;
+
+	case MCE_DISPLAY_DIM:
+		state = MCE_DISPLAY_DIM_STRING;
+		break;
+
+	case MCE_DISPLAY_ON:
+	default:
+		state = MCE_DISPLAY_ON_STRING;
+		break;
+	}
+	if ((is_tvout_state_changed == TRUE) && (display_state == MCE_DISPLAY_OFF)) {
+		state = is_tvout_on ? MCE_DISPLAY_ON_STRING : MCE_DISPLAY_OFF_STRING;
+	}
+	mce_log(LL_DEBUG,
+		"%s: Sending display status: %s", MODULE_NAME,
+		state);
+
+	/* If method_call is set, send a reply,
+	 * otherwise, send a signal
+	 */
+
+	if ((is_tvout_on) && (display_state == MCE_DISPLAY_OFF) && (!is_tvout_state_changed)){
+		goto EXIT;
+	}
+	else
+	{
+		if (method_call != NULL) {
+			msg = dbus_new_method_reply(method_call);
+		} else {
+			/* display_status_ind */
+			msg = dbus_new_signal(MCE_SIGNAL_PATH, MCE_SIGNAL_IF,
+						  MCE_DISPLAY_SIG);
+		}
+		/* Append the display status */
+		if (dbus_message_append_args(msg,
+						 DBUS_TYPE_STRING, &state,
+						 DBUS_TYPE_INVALID) == FALSE) {
+			mce_log(LL_CRIT,
+				"Failed to append %sargument to D-Bus message "
+				"for %s.%s",
+				method_call ? "reply " : "",
+				method_call ? MCE_REQUEST_IF :
+						  MCE_SIGNAL_IF,
+				method_call ? MCE_DISPLAY_STATUS_GET :
+						  MCE_DISPLAY_SIG);
+			dbus_message_unref(msg);
+			goto EXIT;
+		}
+		/* Send the message */
+		status = dbus_send_message(msg);
+	}
+EXIT:
+
+	return status;
+}
+
+/**
+ * D-Bus callback for the get display status method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean display_status_get_dbus_cb(DBusMessage *const msg)
+{
+	gboolean status = FALSE;
+
+	mce_log(LL_DEBUG,
+		"Received display status get request");
+
+	/* Try to send a reply that contains the current display status */
+	if (send_display_status(msg) == FALSE)
+		goto EXIT;
+
+	status = TRUE;
+
+EXIT:
+	return status;
+}
+
+/**
+ * D-Bus callback for the display on method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean display_on_req_dbus_cb(DBusMessage *const msg)
+{
+	dbus_bool_t no_reply = dbus_message_get_no_reply(msg);
+	submode_t submode = mce_get_submode_int32();
+	gboolean status = FALSE;
+
+	mce_log(LL_DEBUG,
+		"Received display on request");
+
+	if ((submode & MCE_TKLOCK_SUBMODE) == 0) {
+		mce_log(LL_DEBUG, "MCE_DISPLAY_ON in %s %s %d",__FILE__, __func__, __LINE__);
+		(void)execute_datapipe(&display_state_pipe,
+				       GINT_TO_POINTER(MCE_DISPLAY_ON),
+				       USE_INDATA, CACHE_INDATA);
+	}
+
+	if (no_reply == FALSE) {
+		DBusMessage *reply = dbus_new_method_reply(msg);
+
+		status = dbus_send_message(reply);
+	} else {
+		status = TRUE;
+	}
+
+	return status;
+}
+
+/**
+ * D-Bus callback for the display dim method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean display_dim_req_dbus_cb(DBusMessage *const msg)
+{
+	dbus_bool_t no_reply = dbus_message_get_no_reply(msg);
+	submode_t submode = mce_get_submode_int32();
+	gboolean status = FALSE;
+
+	mce_log(LL_DEBUG,
+		"Received display dim request");
+
+	/* If the tklock is active, ignore the request */
+	if ((submode & MCE_TKLOCK_SUBMODE) == 0) {
+		(void)execute_datapipe(&display_state_pipe,
+				       GINT_TO_POINTER(MCE_DISPLAY_DIM),
+				       USE_INDATA, CACHE_INDATA);
+	}
+
+	if (no_reply == FALSE) {
+		DBusMessage *reply = dbus_new_method_reply(msg);
+
+		status = dbus_send_message(reply);
+	} else {
+		status = TRUE;
+	}
+
+	return status;
+}
+
+/**
+ * D-Bus callback for the display off method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean display_off_req_dbus_cb(DBusMessage *const msg)
+{
+	dbus_bool_t no_reply = dbus_message_get_no_reply(msg);
+	gboolean status = FALSE;
+
+	mce_log(LL_DEBUG,
+		"Received display off request");
+
+	(void)execute_datapipe(&display_state_pipe,
+			       GINT_TO_POINTER(MCE_DISPLAY_OFF),
+			       USE_INDATA, CACHE_INDATA);
+
+	if (no_reply == FALSE) {
+		DBusMessage *reply = dbus_new_method_reply(msg);
+
+		status = dbus_send_message(reply);
+	} else {
+		status = TRUE;
+	}
+
+	return status;
+}
+
+/**
+ * Handle display state change
+ *
+ * @param data The display state stored in a pointer
+ */
+static void display_state_trigger(gconstpointer data)
+{
+	/** Cached display state */
+	static display_state_t cached_display_state = MCE_DISPLAY_UNDEF;
+	display_state_t display_state = GPOINTER_TO_INT(data);
+
+	switch (display_state) {
+	case MCE_DISPLAY_OFF:
+		cancel_blank_timeout();
+		break;
+
+	case MCE_DISPLAY_DIM:
+		setup_blank_timeout();
+		break;
+
+	case MCE_DISPLAY_ON:
+	default:
+		cancel_blank_timeout();
+		break;
+	}
+
+	/* If we already have the right state,
+	 * we're done here
+	 */
+	if (cached_display_state == display_state)
+		goto EXIT;
+
+	switch (display_state) {
+	case MCE_DISPLAY_OFF:
+		display_blank();
+		break;
+
+	case MCE_DISPLAY_DIM:
+		display_dim();
+		break;
+
+	case MCE_DISPLAY_ON:
+	default:
+		display_unblank();
+		break;
+	}
+
+	/* This will send the correct state
+	 * since the pipe contains the new value
+	 */
+	send_display_status(NULL);
+
+	/* Update the cached value */
+	cached_display_state = display_state;
+
+EXIT:
+	return;
+}
+
+/**
+ * Datapipe trigger for device inactivity
+ *
+ * @param data The inactivity stored in a pointer;
+ *             TRUE if the device is inactive,
+ *             FALSE if the device is active
+ */
+static void device_inactive_trigger(gconstpointer data)
+{
+	system_state_t system_state = datapipe_get_gint(system_state_pipe);
+	display_state_t display_state = datapipe_get_gint(display_state_pipe);
+	alarm_ui_state_t alarm_ui_state = datapipe_get_gint(alarm_ui_state_pipe);
+	gboolean device_inactive = GPOINTER_TO_INT(data);
+
+	/* Unblank screen on device activity,
+	 * unless the device is in acting dead and no alarm is visible
+	 */
+	if (((system_state == MCE_STATE_USER) ||
+		((system_state == MCE_STATE_ACTDEAD) &&
+		((alarm_ui_state == MCE_ALARM_UI_VISIBLE_INT32) ||
+		(alarm_ui_state == MCE_ALARM_UI_RINGING_INT32)))) &&
+		(device_inactive == FALSE)) {
+		(void)execute_datapipe(&display_state_pipe,
+					GINT_TO_POINTER(MCE_DISPLAY_ON),
+					USE_INDATA, CACHE_INDATA);
+	} else if ((system_state == MCE_STATE_USER || system_state == MCE_STATE_ACTDEAD) &&
+				device_inactive == TRUE && display_state == MCE_DISPLAY_ON) {
+		(void)execute_datapipe(&display_state_pipe,
+					GINT_TO_POINTER(MCE_DISPLAY_DIM),
+					USE_INDATA, CACHE_INDATA);
+	}
+}
+
+static void tvout_trigger(gconstpointer data)
+{
+	display_state_t display_state = datapipe_get_gint(display_state_pipe);
+	gboolean is_tvout_on = GPOINTER_TO_INT(data);
+	
+	mce_log(LL_DEBUG, "Recieved tvout state changing: is_tvout_on = %d", is_tvout_on);	
+	
+	if (display_state == MCE_DISPLAY_OFF) {
+		is_tvout_state_changed = TRUE;
+		send_display_status(NULL);
+		is_tvout_state_changed = FALSE;
+	}
+	return;
+}
+
+/**
+ * Get the display type
+ *
+ * @return The display type
+ */
+static bool get_display(void)
+{
+	bool ret = false;
+	gchar *bright_file, *max_bright_file = NULL;
+	const char *path;
+	GDir* dir;
+	
+	/* Attempt to find first entry in /backlight */
+	dir = g_dir_open(DISPLAY_GENERIC_PATH, 0, NULL);
+	if (dir) {
+		path = g_dir_read_name(dir);
+		if (path) {
+			bright_file = g_strconcat(DISPLAY_GENERIC_PATH, path, DISPLAY_GENERIC_BRIGHTNESS_FILE, NULL);
+			max_bright_file = g_strconcat(DISPLAY_GENERIC_PATH, path, DISPLAY_GENERIC_MAX_BRIGHTNESS_FILE, NULL);
+
+			if ((g_access(bright_file, W_OK) == 0) && (g_access(max_bright_file, W_OK) == 0)) {
+				/* These will be freed later on, during module unload */
+				brightness_file = bright_file;
+				max_brightness_file = max_bright_file;
+				ret = true;
+			} else {
+				g_free(bright_file);
+				g_free(max_bright_file);
+			}
+		}
+	}
+
+	g_dir_close(dir);
+
+	mce_log(LL_DEBUG, "%s: using %s as backlight brightness", MODULE_NAME, bright_file);
+
+	return ret;
+}
+
+G_MODULE_EXPORT const gchar *g_module_check_init(GModule *module);
+const gchar *g_module_check_init(GModule *module)
+{
+	gint disp_brightness = DEFAULT_DISP_BRIGHTNESS;
+	gulong tmp;
+
+	(void)module;
+	
+	if (!get_display()) {
+		mce_log(LL_ERR, "%s: Could not find display backlight", MODULE_NAME);
+		goto EXIT;
+	}
+		
+
+	/* Append triggers/filters to datapipes */
+	append_output_trigger_to_datapipe(&display_brightness_pipe,
+					  display_brightness_trigger);
+	append_output_trigger_to_datapipe(&display_state_pipe,
+					  display_state_trigger);
+	append_output_trigger_to_datapipe(&device_inactive_pipe,
+					  device_inactive_trigger);
+	append_output_trigger_to_datapipe(&tvout_pipe, 
+					  tvout_trigger);
+	/* Get maximum brightness */
+	if (mce_read_number_string_from_file(max_brightness_file,
+					     &tmp) == FALSE) {
+		mce_log(LL_ERR,
+			"%s: Could not read the maximum brightness from %s; "
+			"defaulting to %d", MODULE_NAME,
+			max_brightness_file,
+			DEFAULT_MAXIMUM_DISPLAY_BRIGHTNESS);
+		tmp = DEFAULT_MAXIMUM_DISPLAY_BRIGHTNESS;
+	}
+
+	maximum_display_brightness = tmp;
+
+	/* Display brightness */
+	/* Since we've set a default, error handling is unnecessary */
+	(void)mce_gconf_get_int(MCE_GCONF_DISPLAY_BRIGHTNESS_PATH,
+				&disp_brightness);
+
+	/* Use the current brightness as cached brightness on startup,
+	 * and fade from that value
+	 */
+	if (mce_read_number_string_from_file(brightness_file,
+					     &tmp) == FALSE) {
+		mce_log(LL_ERR,
+			"%s: Could not read the current brightness from %s", MODULE_NAME, brightness_file);
+		cached_brightness = -1;
+	} else {
+		cached_brightness = tmp;
+	}
+
+	(void)execute_datapipe(&display_brightness_pipe,
+			       GINT_TO_POINTER(disp_brightness),
+			       USE_INDATA, CACHE_INDATA);
+
+	if (mce_gconf_notifier_add(MCE_GCONF_DISPLAY_PATH,
+				   MCE_GCONF_DISPLAY_BRIGHTNESS_PATH,
+				   display_gconf_cb,
+				   &disp_brightness_gconf_cb_id) == FALSE)
+		goto EXIT;
+
+	/* Display blank */
+	/* Since we've set a default, error handling is unnecessary */
+	(void)mce_gconf_get_int(MCE_GCONF_DISPLAY_BLANK_TIMEOUT_PATH,
+				&disp_blank_timeout);
+
+	if (mce_gconf_notifier_add(MCE_GCONF_DISPLAY_PATH,
+				   MCE_GCONF_DISPLAY_BLANK_TIMEOUT_PATH,
+				   display_gconf_cb,
+				   &disp_blank_timeout_gconf_cb_id) == FALSE)
+		goto EXIT;
+	
+	/* get_display_status */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_DISPLAY_STATUS_GET,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 display_status_get_dbus_cb) == NULL)
+		goto EXIT;
+
+	/* req_display_state_on */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_DISPLAY_ON_REQ,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 display_on_req_dbus_cb) == NULL)
+		goto EXIT;
+
+	/* req_display_state_dim */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_DISPLAY_DIM_REQ,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 display_dim_req_dbus_cb) == NULL)
+		goto EXIT;
+
+	/* req_display_state_off */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_DISPLAY_OFF_REQ,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 display_off_req_dbus_cb) == NULL)
+		goto EXIT;
+
+	/* Request display on to get the state machine in sync */
+	(void)execute_datapipe(&display_state_pipe,
+			       GINT_TO_POINTER(MCE_DISPLAY_ON),
+			       USE_INDATA, CACHE_INDATA);
+
+EXIT:
+	return NULL;
+}
+
+G_MODULE_EXPORT void g_module_unload(GModule *module);
+void g_module_unload(GModule *module)
+{
+	(void)module;
+
+	/* Remove triggers/filters from datapipes */
+	remove_output_trigger_from_datapipe(&tvout_pipe, 
+					  tvout_trigger);
+	remove_output_trigger_from_datapipe(&device_inactive_pipe,
+					    device_inactive_trigger);
+	remove_output_trigger_from_datapipe(&display_state_pipe,
+					    display_state_trigger);
+	remove_output_trigger_from_datapipe(&display_brightness_pipe,
+					    display_brightness_trigger);
+
+	/* Free strings */
+	g_free(brightness_file);
+	g_free(max_brightness_file);
+
+	/* Remove all timer sources */
+	cancel_brightness_fade_timeout();
+	cancel_blank_timeout();
+
+	return;
+}

--- a/modules/display-dev.c
+++ b/modules/display-dev.c
@@ -717,7 +717,8 @@ static void tvout_trigger(gconstpointer data)
 static bool get_display(void)
 {
 	bool ret = false;
-	gchar *bright_file, *max_bright_file = NULL;
+	gchar *bright_file = NULL;
+	gchar *max_bright_file = NULL;
 	const char *path;
 	GDir* dir;
 	
@@ -742,8 +743,9 @@ static bool get_display(void)
 	}
 
 	g_dir_close(dir);
-
-	mce_log(LL_DEBUG, "%s: using %s as backlight brightness", MODULE_NAME, bright_file);
+	
+	if (bright_file)
+		mce_log(LL_DEBUG, "%s: using %s as backlight brightness", MODULE_NAME, bright_file);
 
 	return ret;
 }

--- a/modules/display-dev.h
+++ b/modules/display-dev.h
@@ -1,0 +1,56 @@
+/**
+ * @file display.h
+ * Headers for the display module
+ * <p>
+ * Copyright © 2007-2010 Nokia Corporation and/or its subsidiary(-ies).
+ * <p>
+ * @author David Weinehall <david.weinehall@nokia.com>
+ * @author Jonathan Wilson <jfwfreo@tpgi.com.au>
+ *
+ * mce is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * mce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mce.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef _DISPLAY_H_
+#define _DISPLAY_H_
+
+/** Path to the SysFS entry for the generic display interface */
+#define DISPLAY_GENERIC_PATH			"/sys/class/backlight/"
+/** Generic brightness file */
+#define DISPLAY_GENERIC_BRIGHTNESS_FILE		"/brightness"
+/** Generic maximum brightness file */
+#define DISPLAY_GENERIC_MAX_BRIGHTNESS_FILE	"/max_brightness"
+
+/** Path to the framebuffer device */
+#define FB_DEVICE				"/dev/fb0"
+
+/** Path to the GConf settings for the display */
+#ifndef MCE_GCONF_DISPLAY_PATH
+#define MCE_GCONF_DISPLAY_PATH			"/system/osso/dsm/display"
+#endif /* MCE_GCONF_DISPLAY_PATH */
+#define MCE_GCONF_DISPLAY_BRIGHTNESS_PATH	MCE_GCONF_DISPLAY_PATH "/display_brightness"
+#define MCE_GCONF_DISPLAY_BLANK_TIMEOUT_PATH	MCE_GCONF_DISPLAY_PATH "/display_blank_timeout"
+#define MCE_GCONF_BLANKING_INHIBIT_MODE_PATH	MCE_GCONF_DISPLAY_PATH "/inhibit_blank_mode"
+
+#define DEFAULT_DISP_BRIGHTNESS			3	/* 60% */
+#define DEFAULT_BLANK_TIMEOUT			3	/* 3 seconds */
+#define DEFAULT_ACTDEAD_DIM_TIMEOUT		5	/* 5 seconds */
+#define BOOTUP_DIM_ADDITIONAL_TIMEOUT		60	/* 60 seconds */
+
+/**
+ * Default maximum brightness;
+ * used if the maximum brightness cannot be read from SysFS
+ */
+#define DEFAULT_MAXIMUM_DISPLAY_BRIGHTNESS	127
+#define DEFAULT_DIM_BRIGHTNESS			3
+#define DEFAULT_ENABLE_POWER_SAVING		TRUE
+
+#endif /* _DISPLAY_H_ */

--- a/modules/inactivity-dev.c
+++ b/modules/inactivity-dev.c
@@ -1,0 +1,439 @@
+/**
+ * @file inactivity.c
+ * Inactivity module -- this implements inactivity logic for MCE
+ * <p>
+ * Copyright © 2007-2009 Nokia Corporation and/or its subsidiary(-ies).
+ * <p>
+ * @author David Weinehall <david.weinehall@nokia.com>
+ * @author Jonathan Wilson <jfwfreo@tpgi.com.au>
+ *
+ * mce is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * mce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mce.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <glib.h>
+#include <gmodule.h>
+#include <stdbool.h>
+#include "mce.h"
+#include "mce-log.h"
+#include "mce-dbus.h"
+#include "mce-gconf.h"
+#include "datapipe.h"
+
+#define DEFAULT_TIMEOUT			30	/* 30 seconds */
+
+/** Path to the GConf settings for the display now also used by inactivity.c */
+#ifndef MCE_GCONF_DISPLAY_PATH
+#define MCE_GCONF_DISPLAY_PATH			"/system/osso/dsm/display"
+#endif /* MCE_GCONF_DISPLAY_PATH */
+#define MCE_GCONF_DISPLAY_DIM_TIMEOUT_PATH	MCE_GCONF_DISPLAY_PATH "/display_dim_timeout"
+#define MCE_GCONF_BLANKING_INHIBIT_MODE_PATH	MCE_GCONF_DISPLAY_PATH "/inhibit_blank_mode"
+
+/**
+ * inactiveity prevent timeout, in seconds;
+ * Don't alter this, since this is part of the defined behaviour
+ * for blanking inhibit that applications rely on
+ */
+#define INACTIVITY_PREVENT_TIMEOUT			60	/* 60 seconds */
+
+/** Module name */
+#define MODULE_NAME		"inactivity-dev"
+
+/** Functionality provided by this module */
+static const gchar *const provides[] = { MODULE_NAME, NULL };
+
+/** Module information */
+G_MODULE_EXPORT module_info_struct module_info = {
+	/** Name of the module */
+	.name = MODULE_NAME,
+	/** Module provides */
+	.provides = provides,
+	/** Module priority */
+	.priority = 250
+};
+
+/** Inhibit type */
+typedef enum {
+	/** Inhibit value invalid */
+	INHIBIT_INVALID = -1,
+	/** No inhibit */
+	INHIBIT_OFF = 0,
+	/** Default value */
+	DEFAULT_BLANKING_INHIBIT_MODE = INHIBIT_OFF,
+	/** Inhibit blanking; always keep on if charger connected */
+	INHIBIT_STAY_ON_WITH_CHARGER = 1,
+	/** Inhibit blanking; always keep on or dimmed if charger connected */
+	INHIBIT_STAY_DIM_WITH_CHARGER = 2,
+	/** Inhibit blanking; always keep on */
+	INHIBIT_STAY_ON = 3,
+	/** Inhibit blanking; always keep on or dimmed */
+	INHIBIT_STAY_DIM = 4,
+} inhibit_t;
+
+/** Display blanking inhibit mode */
+static inhibit_t inactivity_inhibit_mode = DEFAULT_BLANKING_INHIBIT_MODE;
+
+/** ID for inactivity timeout source */
+static guint inactivity_timeout_cb_id = 0;
+static guint inactivity_timeout_gconf_cb_id = 0;
+static guint inactivity_inhibit_gconf_cb_id = 0;
+
+static gint inactivity_timeout = DEFAULT_TIMEOUT;
+
+/**
+ * Enable/Disable blanking inhibit,
+ * based on charger status and inhibit mode
+ *
+ * @param timed_inhibit TRUE for timed inhibiting,
+ *                      FALSE for triggered inhibiting
+ */
+static bool inactiveity_inhibited(void)
+{
+	bool blanking_inhibited = false;
+	system_state_t system_state = datapipe_get_gint(system_state_pipe);
+	call_state_t call_state = datapipe_get_gint(call_state_pipe);
+	gboolean charger_connected = datapipe_get_gint(charger_state_pipe);
+	gboolean inactiveity_prevented_by_timeout = datapipe_get_gint(device_lock_inhibit_pipe);
+
+	if ((call_state == CALL_STATE_RINGING) ||
+	    ((charger_connected == TRUE) &&
+	     ((system_state == MCE_STATE_ACTDEAD) ||
+	      ((inactivity_inhibit_mode == INHIBIT_STAY_ON_WITH_CHARGER) ||
+	       (inactivity_inhibit_mode == INHIBIT_STAY_DIM_WITH_CHARGER)))) ||
+	    (inactivity_inhibit_mode == INHIBIT_STAY_ON) ||
+	    (inactivity_inhibit_mode == INHIBIT_STAY_DIM) ||
+		inactiveity_prevented_by_timeout) {
+		/* Always inhibit blanking */
+		blanking_inhibited = true;
+	}
+	return blanking_inhibited;
+}
+
+/**
+ * Send an inactivity status reply or signal
+ *
+ * @param method_call A DBusMessage to reply to;
+ *                    pass NULL to send an inactivity status signal instead
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean send_inactivity_status(DBusMessage *const method_call)
+{
+	DBusMessage *msg = NULL;
+	dbus_bool_t device_inactive = datapipe_get_gbool(device_inactive_pipe);
+	gboolean status = FALSE;
+
+	mce_log(LL_DEBUG,
+		"Sending inactivity status: %s",
+		device_inactive ? "inactive" : "active");
+
+	/* If method_call is set, send a reply,
+	 * otherwise, send a signal
+	 */
+	if (method_call != NULL) {
+		msg = dbus_new_method_reply(method_call);
+	} else {
+		/* system_inactivity_ind */
+		msg = dbus_new_signal(MCE_SIGNAL_PATH, MCE_SIGNAL_IF,
+				      MCE_INACTIVITY_SIG);
+	}
+
+	/* Append the inactivity status */
+	if (dbus_message_append_args(msg,
+				     DBUS_TYPE_BOOLEAN, &device_inactive,
+				     DBUS_TYPE_INVALID) == FALSE) {
+		mce_log(LL_CRIT,
+			"Failed to append %sargument to D-Bus message "
+			"for %s.%s",
+			method_call ? "reply " : "",
+			method_call ? MCE_REQUEST_IF :
+				      MCE_SIGNAL_IF,
+			method_call ? MCE_INACTIVITY_STATUS_GET :
+				      MCE_INACTIVITY_SIG);
+		dbus_message_unref(msg);
+		goto EXIT;
+	}
+
+	/* Send the message */
+	status = dbus_send_message(msg);
+
+EXIT:
+	return status;
+}
+
+/**
+ * D-Bus callback for the get inactivity status method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean inactivity_status_get_dbus_cb(DBusMessage *const msg)
+{
+	gboolean status = FALSE;
+
+	mce_log(LL_DEBUG, "Received inactivity status get request");
+
+	/* Try to send a reply that contains the current inactivity status */
+	if (send_inactivity_status(msg) == FALSE)
+		goto EXIT;
+
+	status = TRUE;
+
+EXIT:
+	return status;
+}
+
+/**
+ * Timeout callback for inactivity
+ *
+ * @param data Unused
+ */
+static gboolean inactivity_timeout_cb(gpointer data)
+{
+	(void)data;
+
+	inactivity_timeout_cb_id = 0;
+	
+	if(inactiveity_inhibited())
+		return TRUE;
+
+	(void)execute_datapipe(&device_inactive_pipe, GINT_TO_POINTER(TRUE),
+			       USE_INDATA, CACHE_INDATA);
+
+	return FALSE;
+}
+
+/**
+ * Cancel inactivity timeout
+ */
+static void cancel_inactivity_timeout(void)
+{
+	/* Remove inactivity timeout source */
+	if (inactivity_timeout_cb_id != 0) {
+		g_source_remove(inactivity_timeout_cb_id);
+		inactivity_timeout_cb_id = 0;
+	}
+}
+
+/**
+ * Setup inactivity timeout
+ */
+static void setup_inactivity_timeout(void)
+{
+	mce_log(LL_DEBUG, "%s: device inactiveity timeout %i", MODULE_NAME, inactivity_timeout);
+
+	cancel_inactivity_timeout();
+
+	/* Sanitise timeout */
+	if (inactivity_timeout <= 0)
+		inactivity_timeout = 30;
+
+	/* Setup new timeout */
+	inactivity_timeout_cb_id = g_timeout_add_seconds(inactivity_timeout, inactivity_timeout_cb, NULL);
+}
+
+/**
+ * Datapipe filter for inactivity
+ *
+ * @param data The unfiltered inactivity state;
+ *             TRUE if the device is inactive,
+ *             FALSE if the device is active
+ * @return The filtered inactivity state;
+ *             TRUE if the device is inactive,
+ *             FALSE if the device is active
+ */
+static gpointer device_inactive_filter(gpointer data)
+{
+	static gboolean old_device_inactive = FALSE;
+	gboolean device_inactive = GPOINTER_TO_INT(data);
+	submode_t submode = mce_get_submode_int32();
+	alarm_ui_state_t alarm_ui_state = datapipe_get_gint(alarm_ui_state_pipe);
+	display_state_t display_state = datapipe_get_gint(display_state_pipe);
+
+	/* Only send the inactivity status on dbus if it changed */
+	if ((old_device_inactive != (device_inactive == TRUE)) &&
+	    (((submode & MCE_TKLOCK_SUBMODE) == 0) ||
+	     (device_inactive == TRUE)))
+		send_inactivity_status(NULL);
+
+	/* Only send the inactivity status on dbus if it changed */
+	if ((device_inactive == FALSE) &&
+	    ((submode & MCE_TKLOCK_SUBMODE) != 0) &&
+	    ((submode & MCE_VISUAL_TKLOCK_SUBMODE) == 0) &&
+	    (((alarm_ui_state != MCE_ALARM_UI_VISIBLE_INT32) &&
+	      (alarm_ui_state != MCE_ALARM_UI_RINGING_INT32)) ||
+	     (((submode & MCE_AUTORELOCK_SUBMODE) != 0) &&
+	      (display_state == MCE_DISPLAY_OFF)))) {
+		data = GINT_TO_POINTER(TRUE);
+		device_inactive = GPOINTER_TO_INT(data);
+	}
+	
+		/* We got activity; restart timeouts */
+	if (device_inactive == FALSE)
+		setup_inactivity_timeout();
+	
+	old_device_inactive = device_inactive;
+
+	return data;
+}
+
+/**
+ * Inactivity timeout trigger
+ *
+ * @param data Unused
+ */
+static void inactivity_timeout_trigger(gconstpointer data)
+{
+	(void)data;
+
+	setup_inactivity_timeout();
+}
+
+/**
+ * Handle display state change
+ *
+ * @param data The display state stored in a pointer
+ */
+static gpointer display_state_filter(gpointer data)
+{
+	display_state_t display_state = GPOINTER_TO_INT(data);
+
+	switch (display_state) {
+	case MCE_DISPLAY_OFF:
+		cancel_inactivity_timeout();
+		execute_datapipe(&device_inactive_pipe, GINT_TO_POINTER(TRUE), USE_INDATA, CACHE_INDATA);
+		break;
+
+	case MCE_DISPLAY_ON:
+	default:
+		setup_inactivity_timeout();
+		break;
+	}
+	
+	return data;
+}
+
+
+/**
+ * GConf callback for display related settings
+ * 
+ * @param gcc Unused
+ * @param id Connection ID from gconf_client_notify_add()
+ * @param entry The modified GConf entry
+ * @param data Unused
+ */
+static void inactiveity_gconf_cb(GConfClient *const gcc, const guint id,
+			     GConfEntry *const entry, gpointer const data)
+{
+	GConfValue *gcv = gconf_entry_get_value(entry);
+
+	(void)gcc;
+	(void)data;
+
+	/* Key is unset */
+	if (gcv == NULL) {
+		mce_log(LL_DEBUG,
+			"GConf Key `%s' has been unset",
+			gconf_entry_get_key(entry));
+		goto EXIT;
+	}
+
+	if (id == inactivity_timeout_gconf_cb_id) {
+		inactivity_timeout = gconf_value_get_int(gcv);
+		mce_log(LL_DEBUG, "%s: inactivity_timeout set to %i", MODULE_NAME, inactivity_timeout);
+	} else if (id == inactivity_inhibit_gconf_cb_id) {
+		inactivity_inhibit_mode = gconf_value_get_int(gcv);
+	} else {
+		mce_log(LL_WARN, "%s: Spurious GConf value received; confused!", MODULE_NAME);
+	}
+
+EXIT:
+	return;
+}
+
+/**
+ * Init function for the inactivity module
+ *
+ * @todo XXX status needs to be set on error!
+ *
+ * @param module Unused
+ * @return NULL on success, a string with an error message on failure
+ */
+G_MODULE_EXPORT const gchar *g_module_check_init(GModule *module);
+const gchar *g_module_check_init(GModule *module)
+{
+	(void)module;
+
+	/* Append triggers/filters to datapipes */
+	append_filter_to_datapipe(&device_inactive_pipe,
+				  device_inactive_filter);
+	append_output_trigger_to_datapipe(&inactivity_timeout_pipe,
+					  inactivity_timeout_trigger);
+	append_filter_to_datapipe(&display_state_pipe,
+					display_state_filter);
+	
+	/* Since we've set a default, error handling is unnecessary */
+	(void)mce_gconf_get_int(MCE_GCONF_DISPLAY_DIM_TIMEOUT_PATH,
+				&inactivity_timeout);
+
+	if (mce_gconf_notifier_add(MCE_GCONF_DISPLAY_PATH,
+				   MCE_GCONF_DISPLAY_DIM_TIMEOUT_PATH,
+				   inactiveity_gconf_cb,
+				   &inactivity_timeout_gconf_cb_id) == FALSE)
+		goto EXIT;
+	
+	(void)mce_gconf_get_int(MCE_GCONF_BLANKING_INHIBIT_MODE_PATH,
+				&inactivity_inhibit_mode);
+
+	if (mce_gconf_notifier_add(MCE_GCONF_DISPLAY_PATH,
+				   MCE_GCONF_BLANKING_INHIBIT_MODE_PATH,
+				   inactiveity_gconf_cb,
+				   &inactivity_inhibit_gconf_cb_id) == FALSE)
+		goto EXIT;
+
+	/* get_inactivity_status */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_INACTIVITY_STATUS_GET,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 inactivity_status_get_dbus_cb) == NULL)
+		goto EXIT;
+
+	setup_inactivity_timeout();
+
+EXIT:
+	return NULL;
+}
+
+/**
+ * Exit function for the inactivity module
+ *
+ * @todo D-Bus unregistration
+ *
+ * @param module Unused
+ */
+G_MODULE_EXPORT void g_module_unload(GModule *module);
+void g_module_unload(GModule *module)
+{
+	(void)module;
+
+	/* Remove triggers/filters from datapipes */
+	remove_filter_from_datapipe(&device_inactive_pipe,
+				    device_inactive_filter);
+	remove_output_trigger_from_datapipe(&inactivity_timeout_pipe,
+					  inactivity_timeout_trigger);
+	remove_filter_from_datapipe(&display_state_pipe,
+					display_state_filter);
+
+	/* Remove all timer sources */
+	cancel_inactivity_timeout();
+
+	return;
+}


### PR DESCRIPTION
This fixes the race that https://github.com/maemo-leste/mce/pull/12 exposes and refactors display.c and inactivity.c to allow inactivity.c to work correctly. This was compleatly broken before with display.c and inactivity.c implementing the inactivity timer twice in parallel, while creating some interesting race conditions. For now the refactored code is in its own modules (-dev variants of display.c and inactivity.c)

The refactored variants are mostly feature compleat except:
 1. no CABC support in display-dev.c
    1. i need to do this in a generic way
    2. id like to do this in a seperate module
    3. No device supports this in the mainline kernel/via the drm interface, n900 might via non-standard sysfs not sure.
    4. maybe drop this feature
  2. timed inactivity inhibit dbus calls are not suppored
     1. i will provide a inactivity-inhibit module to provide this, working on it atm.