### PR TITLE
Add led-sw and led-dbus modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ MODULES := \
 	$(MODULE_DIR)/libbattery-upower.so \
 	$(MODULE_DIR)/libdisplay.so \
 	$(MODULE_DIR)/libled.so \
+	$(MODULE_DIR)/libled-sw.so \
+	$(MODULE_DIR)/libled-dbus.so \
 	$(MODULE_DIR)/libevdevvibrator.so \
 	$(MODULE_DIR)/libaccelerometer.so \
 	$(MODULE_DIR)/libcallstate.so \

--- a/mce.c
+++ b/mce.c
@@ -508,6 +508,8 @@ int main(int argc, char **argv)
 		       0, NULL);
 	setup_datapipe(&led_pattern_deactivate_pipe, READ_ONLY, FREE_CACHE,
 		       0, NULL);
+	setup_datapipe(&led_enabled_pipe, READ_WRITE, DONT_FREE_CACHE,
+		       0, GINT_TO_POINTER(TRUE));
 	setup_datapipe(&vibrator_pattern_activate_pipe, READ_ONLY, FREE_CACHE,
 		       0, NULL);
 	setup_datapipe(&vibrator_pattern_deactivate_pipe, READ_ONLY, FREE_CACHE,

--- a/mce.h
+++ b/mce.h
@@ -264,6 +264,8 @@ datapipe_struct device_inactive_pipe;
 datapipe_struct led_pattern_activate_pipe;
 /** LED pattern to deactivate; read only */
 datapipe_struct led_pattern_deactivate_pipe;
+/** LED enabled / disabled */
+datapipe_struct led_enabled_pipe;
 datapipe_struct vibrator_pattern_activate_pipe;
 datapipe_struct vibrator_pattern_deactivate_pipe;
 /** State of display; read only */

--- a/mce.ini
+++ b/mce.ini
@@ -232,16 +232,19 @@ BacklightFadeTime=100
 # A list of all pattern names that should be configured
 LEDPatterns=PatternError;PatternDeviceOn;PatternPowerOn;PatternPowerOff;PatternCommunicationCall;PatternCommunicationIM;PatternCommunicationSMS;PatternCommunicationEmail;PatternCommonNotification;PatternWebcamActive;PatternBatteryCharging;PatternBatteryFull;PatternDeviceSoftOff;PatternBoost
 
+[LEDGenericSoftware]
 
-[LEDPatternMonoRX34]
+# Put a 1 here if your device has only a single led, only WhiteSysfs will then be used
+Monochromic=0
 
-# Patterns used if the device has a single-colour LED
+# Set the names of the folders in /sys/class/led/ of the leds you want to use here
+#WhiteSysfs=
+#RedSysfs=
+#GreenSysfs=
+#BlueSysfs=
+
+# Patterns used if the device has an RGB LED connected to a Lysti controller
 # Please prefix pattern names with Pattern to avoid name space clashes
-#
-# Note: For power management purposes, remember to keep try to keep the
-#       onPeriod relatively short (not shorter than 50ms though),
-#       the offPeriod long; if this is not possible, make sure to have
-#       a timeout for the pattern so that it goes off after 15-30 seconds
 #
 # Priority (0 - highest, 255 - lowest)
 # ScreenOn - 0 only show pattern when the display is off
@@ -250,31 +253,28 @@ LEDPatterns=PatternError;PatternDeviceOn;PatternPowerOn;PatternPowerOff;PatternC
 #            3 show pattern even when the display is on, including acting dead
 #            4 only show pattern if the display is off, or if in acting dead
 #            5 always show pattern, even if LED disabled
-# Timeout in seconds before pattern is disabled, 0 for infinite
-# OnPeriod time in milliseconds
-# OffPeriod time in milliseconds
-#      (0 for continuous light; ONLY when the charger is connected!)
-# Intensity in steps from 0 (off) to 15 (full intensity)
-PatternError=0;5;0;250;500;15
-PatternDeviceOn=254;0;0;75;5000;10
-PatternDeviceSoftOff=253;0;0;100;10000;5
-PatternPowerOn=9;3;0;2000;1000;15
-PatternPowerOff=10;3;0;2000;1000;15
-PatternCommunicationCall=30;1;0;250;2000;15
-PatternCommunicationIM=30;1;0;250;2000;15
-PatternCommunicationSMS=30;1;0;250;2000;15
-PatternCommunicationEmail=30;1;0;250;2000;15
-PatternCommonNotification=30;1;0;250;2000;15
-PatternWebcamActive=255;0;0;0;0;0
-PatternBatteryCharging=50;4;0;500;7500;10
-PatternBatteryFull=40;4;0;1500;0;10
+# Timeout in seconds before pattern is disabled in seconds, 0 for infinite
+# Brighness of the red led
+# Brighness of the green led
+# Brighness of the blue led
+# onPeriod  - time the led spends on in ms
+# offPeriod - time the led spends off in ms, zero for allways on
 
-# This example pattern has a priority of 42 (all patterns with a *lower*
-# priority value will have precedence), an on-period of 0.5 seconds,
-# and an off-period of 1.5 seconds.  The pattern will be active for
-# 30 seconds, then stop.  The brightness level will be 10 (with 15 being
-# the maximum, this would amount to 66%.
-# This pattern will be visible even when the display is on.
+PatternError=0;5;0;255;0;0;100;100
+PatternDeviceOn=254;0;0;0;0;0;1000;1000
+PatternDeviceSoftOff=253;0;0;0;0;0;1000;1000
+PatternPowerOn=9;3;0;128;0;128;2000;500
+PatternPowerOff=9;3;0;128;0;128;500;2000
+PatternCommunicationCall=25;1;0;0;255;0;500;2000
+PatternCommunicationIM=28;1;0;0;255;255;500;2000
+PatternCommunicationSMS=26;1;0;0;255;0;500;2000
+PatternCommunicationEmail=27;1;0;255;255;255;500;2000
+PatternCommonNotification=30;1;0;0;0;255;500;1000
+PatternWebcamActive=20;5;0;0;0;255;1000;0
+PatternBatteryCharging=50;3;0;128;0;255;1000;0
+PatternBatteryFull=40;3;0;0;255;255;1000;0
+PatternBoost=35;5;0;255;0;0;2000;2000
+
 PatternExample=42;1;30;500;1500;10
 
 
@@ -458,7 +458,6 @@ PatternBoost=35;5;0;b;9d804000043fc0000000;9d800000
 # priority value will have precedence), and will flash in yellow
 # This pattern will be visible even when the display is on.
 PatternExample=42;1;30;rg;9d80400044ff45ff0000;9d800000
-
 
 [Vibrator]
 

--- a/modules/led-dbus.c
+++ b/modules/led-dbus.c
@@ -1,0 +1,237 @@
+/* This module supplys a dbus interface to the notification led.*/
+
+#include <glib.h>
+#include <gmodule.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "mce-log.h"
+#include "mce-dbus.h"
+#include "datapipe.h"
+#include "mce.h"
+
+/** Module name */
+#define MODULE_NAME		"led-dbus"
+#define MODULE_PROVIDES	"led-dbus"
+
+#define LED_SYSFS_PATH "/sys/class/leds/"
+#define LED_BRIGHTNESS_PATH "/brightness"
+
+/** Functionality provided by this module */
+static const gchar *const provides[] = { MODULE_PROVIDES, NULL };
+
+/** Module information */
+G_MODULE_EXPORT module_info_struct module_info = {
+	/** Name of the module */
+	.name = MODULE_NAME,
+	/** Module provides */
+	.provides = provides,
+	/** Module priority */
+	.priority = 100
+};
+
+/**
+ * D-Bus callback for the activate LED pattern method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean led_activate_pattern_dbus_cb(DBusMessage *const msg)
+{
+	dbus_bool_t no_reply = dbus_message_get_no_reply(msg);
+	gboolean status = FALSE;
+	gchar *pattern = NULL;
+	DBusError error;
+
+	/* Register error channel */
+	dbus_error_init(&error);
+
+	mce_log(LL_DEBUG, "Received activate LED pattern request");
+
+	if (dbus_message_get_args(msg, &error,
+				  DBUS_TYPE_STRING, &pattern,
+				  DBUS_TYPE_INVALID) == FALSE) {
+		mce_log(LL_CRIT,
+			"Failed to get argument from %s.%s: %s",
+			MCE_REQUEST_IF, MCE_ACTIVATE_LED_PATTERN,
+			error.message);
+		dbus_error_free(&error);
+		return FALSE;
+	}
+
+	execute_datapipe_output_triggers(&led_pattern_activate_pipe, pattern, USE_INDATA);
+
+	if (no_reply == FALSE) {
+		DBusMessage *reply = dbus_new_method_reply(msg);
+
+		status = dbus_send_message(reply);
+	} else {
+		status = TRUE;
+	}
+
+	return status;
+}
+
+/**
+ * D-Bus callback for the deactivate LED pattern method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean led_deactivate_pattern_dbus_cb(DBusMessage *const msg)
+{
+	dbus_bool_t no_reply = dbus_message_get_no_reply(msg);
+	gboolean status = FALSE;
+	gchar *pattern = NULL;
+	DBusError error;
+
+	/* Register error channel */
+	dbus_error_init(&error);
+
+	mce_log(LL_DEBUG, "%s: Received deactivate LED pattern request", MODULE_NAME);
+
+	if (dbus_message_get_args(msg, &error,
+				  DBUS_TYPE_STRING, &pattern,
+				  DBUS_TYPE_INVALID) == FALSE) {
+		mce_log(LL_CRIT, "%s: "
+			"Failed to get argument from %s.%s: %s", MODULE_NAME,
+			MCE_REQUEST_IF, MCE_DEACTIVATE_LED_PATTERN,
+			error.message);
+		dbus_error_free(&error);
+		return FALSE;
+	}
+
+	execute_datapipe_output_triggers(&led_pattern_deactivate_pipe, pattern, USE_INDATA);
+
+	if (no_reply == FALSE) {
+		DBusMessage *reply = dbus_new_method_reply(msg);
+
+		status = dbus_send_message(reply);
+	} else {
+		status = TRUE;
+	}
+
+	return status;
+}
+
+/**
+ * D-Bus callback for the enable LED method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean led_enable_dbus_cb(DBusMessage *const msg)
+{
+	dbus_bool_t no_reply = dbus_message_get_no_reply(msg);
+	gboolean status = FALSE;
+
+	mce_log(LL_DEBUG, "Received LED enable request");
+
+	execute_datapipe_output_triggers(&led_enabled_pipe, GINT_TO_POINTER(true), USE_INDATA);
+
+	if (no_reply == FALSE) {
+		DBusMessage *reply = dbus_new_method_reply(msg);
+
+		status = dbus_send_message(reply);
+	} else {
+		status = TRUE;
+	}
+
+	return status;
+}
+
+/**
+ * D-Bus callback for the disable LED method call
+ *
+ * @param msg The D-Bus message
+ * @return TRUE on success, FALSE on failure
+ */
+static gboolean led_disable_dbus_cb(DBusMessage *const msg)
+{
+	dbus_bool_t no_reply = dbus_message_get_no_reply(msg);
+	gboolean status = FALSE;
+
+	mce_log(LL_DEBUG, "Received LED disable request");
+
+	execute_datapipe_output_triggers(&led_enabled_pipe, GINT_TO_POINTER(false), USE_INDATA);
+
+	if (no_reply == FALSE) {
+		DBusMessage *reply = dbus_new_method_reply(msg);
+
+		status = dbus_send_message(reply);
+	} else {
+		status = TRUE;
+	}
+
+	return status;
+}
+
+/**
+ * Init function for the LED logic module
+ *
+ * @todo XXX status needs to be set on error!
+ *
+ * @param module Unused
+ * @return NULL on success, a string with an error message on failure
+ */
+G_MODULE_EXPORT const gchar *g_module_check_init(GModule *module);
+const gchar *g_module_check_init(GModule *module)
+{
+	(void)module;
+
+	/* req_led_pattern_activate */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_ACTIVATE_LED_PATTERN,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 led_activate_pattern_dbus_cb) == NULL) {
+			mce_log(LL_CRIT, "%s: Adding %s debus handler failed", MODULE_NAME, MCE_ACTIVATE_LED_PATTERN);
+			return NULL;
+		}
+
+	/* req_led_pattern_deactivate */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_DEACTIVATE_LED_PATTERN,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 led_deactivate_pattern_dbus_cb) == NULL) {
+			mce_log(LL_CRIT, "%s: Adding %s debus handler failed", MODULE_NAME, MCE_DEACTIVATE_LED_PATTERN);
+			return NULL;
+		}
+
+	/* req_led_enable */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_ENABLE_LED,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 led_enable_dbus_cb) == NULL) {
+			mce_log(LL_CRIT, "%s: Adding %s debus handler failed", MODULE_NAME, MCE_ENABLE_LED);
+			return NULL;
+		}
+
+	/* req_led_disable */
+	if (mce_dbus_handler_add(MCE_REQUEST_IF,
+				 MCE_DISABLE_LED,
+				 NULL,
+				 DBUS_MESSAGE_TYPE_METHOD_CALL,
+				 led_disable_dbus_cb) == NULL) {
+			mce_log(LL_CRIT, "%s: Adding %s debus handler failed", MODULE_NAME, MCE_DISABLE_LED);
+			return NULL;
+		}
+
+	return NULL;
+}
+
+/**
+ * Exit function for the LED logic module
+ *
+ * @todo D-Bus unregistration
+ *
+ * @param module Unused
+ */
+G_MODULE_EXPORT void g_module_unload(GModule *module);
+void g_module_unload(GModule *module)
+{
+	(void)module;
+}

--- a/modules/led-sw.c
+++ b/modules/led-sw.c
@@ -1,0 +1,477 @@
+/* This module handles notifcation leds on devices without a hardware led controller capable of patterns.*/
+
+#include <glib.h>
+#include <gmodule.h>
+#include <glib/gstdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "mce-log.h"
+#include "mce-conf.h"
+#include "mce-io.h"
+#include "mce-gconf.h"
+#include "datapipe.h"
+#include "mce.h"
+
+#define MCE_CONF_LED_GROUP			"LED"
+#define MCE_CONF_LED_PATTERNS		"LEDPatterns"
+#define MCE_CONF_LED_GENERIC		"LEDGenericSoftware"
+#define MCE_CONF_MONOCHROMIC		"Monochromic"
+#define MCE_CONF_R		"RedSysfs"
+#define MCE_CONF_G		"GreenSysfs"
+#define MCE_CONF_B		"BlueSysfs"
+#define MCE_CONF_W		"WhiteSysfs"
+
+/** Module name */
+#define MODULE_NAME		"led-sw"
+#define MODULE_PROVIDES	"led"
+
+#define LED_SYSFS_PATH "/sys/class/leds/"
+#define LED_BRIGHTNESS_PATH "/brightness"
+
+/** Functionality provided by this module */
+static const gchar *const provides[] = { MODULE_PROVIDES, NULL };
+
+/** Module information */
+G_MODULE_EXPORT module_info_struct module_info = {
+	/** Name of the module */
+	.name = MODULE_NAME,
+	/** Module provides */
+	.provides = provides,
+	/** Module priority */
+	.priority = 100
+};
+
+typedef enum {
+	PATTERN_PRIO_FIELD = 0,
+	PATTERN_POLICY_FIELD = 1,
+	PATTERN_TIMEOUT_FIELD = 2,
+	PATTERN_R_FIELD = 3,
+	PATTERN_G_FIELD = 4,
+	PATTERN_B_FIELD = 5,
+	PATTERN_ON_PERIOD_FIELD = 6,
+	PATTERN_OFF_PERIOD_FIELD = 7,
+	NUMBER_OF_PATTERN_FIELDS
+} pattern_field;
+
+typedef enum {
+    POLICY_PLAY_DISPLAY_OFF = 0,
+    POLICY_PLAY_DISPLAY_ON_OR_OFF = 1,
+    POLICY_PLAY_DISPLAY_OFF_ACTDEAD = 2,
+    POLICY_PLAY_DISPLAY_ON_ACTDEAD = 3,
+    POLICY_PLAY_DISPLAY_OFF_OR_ACTDEAD = 4,
+    POLICY_PLAY_ALWAYS = 5,
+} policy_field;
+
+struct led_pattern {
+	char* name;
+	uint8_t priority;
+	uint8_t policy;
+	unsigned int timeoutSec;
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+	unsigned long onPeriodMs;
+	unsigned long offPeriodMs;
+	
+	bool active;
+	bool ledOn;
+	bool foreground;
+	
+	unsigned int disableTimer;
+	unsigned int periodTimer;
+};
+
+static struct led_pattern *led_patterns = NULL;
+unsigned int patterns_count = 0;
+bool monochromic = false;
+static char* r_sysfs = NULL;
+static char* g_sysfs = NULL;
+static char* b_sysfs = NULL;
+static char* w_sysfs = NULL;
+
+bool led_enabled;
+display_state_t display_state = { 0 };
+system_state_t system_state = { 0 };
+
+static void update_patterns(void);
+
+static bool init_patterns(void)
+{
+	struct led_pattern *led_pattern = NULL;
+	char **patternlist = NULL;
+	gsize length;
+
+	patternlist = mce_conf_get_string_list(MCE_CONF_LED_GROUP,
+					       MCE_CONF_LED_PATTERNS,
+					       &length, NULL);
+
+	if (patternlist == NULL) {
+		mce_log(LL_WARN, "%s: Failed to configure led patterns", MODULE_NAME);
+		return false;
+	}
+
+	led_patterns = malloc(length*sizeof(*led_pattern));
+	if (!led_patterns) {
+		g_strfreev(patternlist);
+		return false;
+	}
+
+	for (int i = 0; patternlist[i]; ++i) {
+		int *tmp;
+
+		mce_log(LL_DEBUG, "%s: Getting led pattern for: %s",
+			MODULE_NAME, patternlist[i]);
+
+		tmp = mce_conf_get_int_list(MCE_CONF_LED_GENERIC,
+					    patternlist[i], &length, NULL);
+		if (tmp != NULL) {
+			struct led_pattern *pattern;
+			
+			if (length != NUMBER_OF_PATTERN_FIELDS) {
+				mce_log(LL_ERR, "%s: Skipping invalid led pattern: %s", MODULE_NAME, patternlist[i]);
+				g_free(tmp);
+				continue;
+			}
+			
+			
+			pattern = &led_patterns[patterns_count];
+			pattern->name = strdup(patternlist[i]);
+			pattern->priority = ABS(tmp[PATTERN_PRIO_FIELD]);
+			pattern->policy = ABS(tmp[PATTERN_POLICY_FIELD]);
+			pattern->timeoutSec = ABS(tmp[PATTERN_TIMEOUT_FIELD]);
+			pattern->onPeriodMs = ABS(tmp[PATTERN_ON_PERIOD_FIELD]);
+			pattern->offPeriodMs = ABS(tmp[PATTERN_OFF_PERIOD_FIELD]);
+			pattern->r = ABS(tmp[PATTERN_R_FIELD]);
+			pattern->g = ABS(tmp[PATTERN_G_FIELD]);
+			pattern->b = ABS(tmp[PATTERN_B_FIELD]);
+
+			pattern->active = false;
+			pattern->foreground = false;
+			pattern->ledOn = false;
+			pattern->disableTimer = 0;
+			pattern->periodTimer = 0;
+			
+			if (pattern->r == 0 && pattern->g == 0 && pattern->b == 0)
+				mce_log(LL_INFO, "%s: Skipping led pattern with zero brighness: %s", MODULE_NAME, patternlist[i]);
+			else
+				++patterns_count;
+
+			g_free(tmp);
+		}
+	}
+	mce_log(LL_DEBUG, "%s: found %i patterns", MODULE_NAME, patterns_count);
+	g_strfreev(patternlist);
+	
+	return true;
+}
+
+static void set_led(uint8_t r, uint8_t g, uint8_t b)
+{
+	if (!monochromic) {
+		mce_write_number_string_to_glob(r_sysfs, r);
+		mce_write_number_string_to_glob(g_sysfs, g);
+		mce_write_number_string_to_glob(b_sysfs, b);
+	} else {
+		mce_write_number_string_to_glob(w_sysfs, (r+g+b)/3);
+	}
+}
+
+static bool should_run_pattern(const struct led_pattern * const pattern)
+{
+	if (pattern->r == 0 && pattern->g == 0 && pattern->b == 0)
+		return false;
+	else if (pattern->policy == POLICY_PLAY_ALWAYS || 
+		(pattern->policy == POLICY_PLAY_DISPLAY_ON_ACTDEAD && led_enabled))
+		return true;
+	else if (pattern->policy == POLICY_PLAY_DISPLAY_OFF_OR_ACTDEAD &&
+		 (system_state == MCE_STATE_ACTDEAD
+		  || display_state == MCE_DISPLAY_OFF))
+		return true;
+	else if (pattern->policy == POLICY_PLAY_DISPLAY_OFF_ACTDEAD &&
+		 (system_state == MCE_STATE_ACTDEAD
+		  && display_state == MCE_DISPLAY_OFF))
+		return true;
+	else if (pattern->policy == POLICY_PLAY_DISPLAY_ON_OR_OFF &&
+		 (system_state != MCE_STATE_ACTDEAD))
+		return true;
+	else if (pattern->policy == POLICY_PLAY_DISPLAY_OFF &&
+		 (system_state != MCE_STATE_ACTDEAD
+		  && display_state == MCE_DISPLAY_OFF))
+		return true;
+	return false;
+}
+
+static gboolean disable_timeout_cb(gpointer data)
+{
+	struct led_pattern *pattern = (struct led_pattern *)data;
+	
+	set_led(0, 0, 0);
+	pattern->ledOn = false;
+	pattern->active = false;
+	
+	update_patterns();
+	
+	return false;
+}
+
+static void cancle_disable_timer(struct led_pattern *pattern)
+{
+	if (pattern->disableTimer != 0) {
+		set_led(0, 0, 0);
+		g_source_remove(pattern->disableTimer);
+		pattern->disableTimer = 0;
+		pattern->foreground = false;
+	}
+}
+
+static void setup_disable_timer(struct led_pattern *pattern)
+{
+	cancle_disable_timer(pattern);
+	
+	if (pattern->timeoutSec > 0)
+		pattern->disableTimer = 
+			g_timeout_add_seconds(pattern->timeoutSec, &disable_timeout_cb, pattern);
+}
+
+static gboolean period_timeout_cb(gpointer data)
+{
+	struct led_pattern *pattern = (struct led_pattern *)data;
+	
+	pattern->ledOn = !pattern->ledOn;
+	
+	if (pattern->ledOn)
+		set_led(pattern->r, pattern->g, pattern->b);
+	else
+		set_led(0, 0, 0);
+		
+	pattern->periodTimer = 
+		g_timeout_add(pattern->ledOn ? pattern->onPeriodMs : pattern->offPeriodMs, &period_timeout_cb, pattern);
+		
+	 return false;
+}
+
+static void cancle_period_timer(struct led_pattern *pattern)
+{
+	if (pattern->periodTimer != 0) {
+		set_led(0, 0, 0);
+		g_source_remove(pattern->periodTimer);
+		pattern->periodTimer = 0;
+		pattern->foreground = false;
+	}
+}
+
+static void setup_period_timer(struct led_pattern *pattern)
+{
+	cancle_period_timer(pattern);
+	
+	if (pattern->offPeriodMs > 0 && pattern->onPeriodMs > 0)
+		pattern->periodTimer = 
+			g_timeout_add(pattern->ledOn ? pattern->onPeriodMs : pattern->offPeriodMs, &period_timeout_cb, pattern);
+}
+
+static void update_patterns(void)
+{
+	struct led_pattern *pattern_to_run = NULL;
+	int prio = 256;
+	for (unsigned int i = 0; i < patterns_count; ++i) {
+		if (!led_patterns[i].active || !should_run_pattern(&led_patterns[i]) || prio < led_patterns[i].priority) {
+			if (led_patterns[i].foreground) {
+				cancle_period_timer(&led_patterns[i]);
+				set_led(0, 0, 0);
+				led_patterns[i].foreground = false;
+				led_patterns[i].ledOn = false;
+			}
+			continue;
+		}
+
+		if (pattern_to_run != NULL) {
+			cancle_period_timer(pattern_to_run);
+			pattern_to_run->foreground = false;
+		}
+
+		prio = led_patterns[i].priority;
+		pattern_to_run = &led_patterns[i];
+	}
+	
+	if (pattern_to_run && pattern_to_run->foreground == false) {
+		set_led(pattern_to_run->r, pattern_to_run->g, pattern_to_run->b);
+		pattern_to_run->ledOn = true;
+		pattern_to_run->foreground = true;
+		setup_period_timer(pattern_to_run);
+	}
+}
+
+static char *led_create_sysfs_path(const gchar *key)
+{
+	char *path = NULL;
+	gchar* tmp = mce_conf_get_string(MCE_CONF_LED_GENERIC, key, NULL, NULL);
+	if (!tmp) {
+		mce_log(LL_ERR, "%s: %s is required to be defined", MODULE_NAME, key);
+		return NULL;
+	}
+	path = malloc(strlen(LED_SYSFS_PATH)+strlen(tmp)+strlen(LED_BRIGHTNESS_PATH)+1);
+	if (!path) 
+		return NULL;
+	strcpy(path, LED_SYSFS_PATH);
+	strcat(path, tmp);
+	strcat(path, LED_BRIGHTNESS_PATH);
+	if (g_access(path, W_OK) != 0) {
+		mce_log(LL_ERR, "%s: Led sysfs path is invalid: %s", MODULE_NAME, path);
+		free(path);
+		return NULL;
+	}
+	return path;
+}
+
+static void system_state_trigger(gconstpointer data)
+{
+	(void)data;
+	system_state = datapipe_get_gint(system_state_pipe);
+	update_patterns();
+}
+
+static void display_state_trigger(gconstpointer data)
+{
+	(void)data;
+	display_state = datapipe_get_gint(display_state_pipe);
+	update_patterns();
+}
+
+static void led_enabled_trigger(gconstpointer data)
+{
+	(void)data;
+	led_enabled = datapipe_get_gbool(led_enabled_pipe);
+	update_patterns();
+}
+
+
+static void led_pattern_activate_trigger(gconstpointer data)
+{
+	const gchar * const name = (const gchar * const)data;
+	bool found = false;
+	for (unsigned int i = 0; i < patterns_count; ++i) {
+		if (strcmp(led_patterns[i].name, name) == 0) {
+			found = true;
+			led_patterns[i].active = true;
+			update_patterns();
+			setup_disable_timer(&led_patterns[i]);
+			mce_log(LL_DEBUG, "%s: activate called on: %s", MODULE_NAME, name);
+			break;
+		}
+	}
+	
+	if (!found)
+		mce_log(LL_WARN, "%s: activate called on non exisiting pattern: %s", MODULE_NAME, name);
+}
+
+static void led_pattern_deactivate_trigger(gconstpointer data)
+{
+	const gchar * const name = (const gchar * const)data;
+	bool found = false;
+	for (unsigned int i = 0; i < patterns_count; ++i) {
+		if (strcmp(led_patterns[i].name, name) == 0) {
+			found = true;
+			led_patterns[i].active = false;
+			update_patterns();
+			cancle_disable_timer(&led_patterns[i]);
+			mce_log(LL_DEBUG, "%s: deactivate called on: %s", MODULE_NAME, name);
+			break;
+		}
+	}
+	
+	if (!found)
+		mce_log(LL_WARN, "%s: deactivate called on non exisiting pattern: %s", MODULE_NAME, name);
+}
+
+
+/**
+ * Init function for the LED logic module
+ *
+ * @todo XXX status needs to be set on error!
+ *
+ * @param module Unused
+ * @return NULL on success, a string with an error message on failure
+ */
+G_MODULE_EXPORT const gchar *g_module_check_init(GModule *module);
+const gchar *g_module_check_init(GModule *module)
+{
+	(void)module;
+
+	monochromic = mce_conf_get_bool(MCE_CONF_LED_GENERIC, MCE_CONF_MONOCHROMIC, false, NULL);
+	if (monochromic) {
+		w_sysfs = led_create_sysfs_path(MCE_CONF_W);
+		if(!w_sysfs)
+			return NULL;
+	} else {
+		r_sysfs = led_create_sysfs_path(MCE_CONF_R);
+		g_sysfs = led_create_sysfs_path(MCE_CONF_G);
+		b_sysfs = led_create_sysfs_path(MCE_CONF_B);
+		if (!r_sysfs || !g_sysfs || !b_sysfs)
+			return NULL;
+	}
+	
+	if (!init_patterns())
+		return NULL;
+	
+	led_enabled = datapipe_get_gbool(led_enabled_pipe);
+	system_state = datapipe_get_gint(system_state_pipe);
+	display_state = datapipe_get_gint(system_state_pipe);
+
+	/* Append triggers/filters to datapipes */
+	append_output_trigger_to_datapipe(&system_state_pipe,
+					  system_state_trigger);
+	append_output_trigger_to_datapipe(&display_state_pipe,
+					  display_state_trigger);
+	append_output_trigger_to_datapipe(&led_pattern_activate_pipe,
+					  led_pattern_activate_trigger);
+	append_output_trigger_to_datapipe(&led_pattern_deactivate_pipe,
+					  led_pattern_deactivate_trigger);
+	append_output_trigger_to_datapipe(&led_enabled_pipe,
+					  led_enabled_trigger);
+
+	return NULL;
+}
+
+G_MODULE_EXPORT void g_module_unload(GModule *module);
+void g_module_unload(GModule *module)
+{
+
+	(void)module;
+
+	/* Remove triggers/filters from datapipes */
+	remove_output_trigger_from_datapipe(&led_pattern_deactivate_pipe,
+					    led_pattern_deactivate_trigger);
+	remove_output_trigger_from_datapipe(&led_pattern_activate_pipe,
+					    led_pattern_activate_trigger);
+	remove_output_trigger_from_datapipe(&led_enabled_pipe,
+					    led_enabled_trigger);
+	remove_output_trigger_from_datapipe(&display_state_pipe,
+					    display_state_trigger);
+	remove_output_trigger_from_datapipe(&system_state_pipe,
+					    system_state_trigger);
+
+	/* Don't disable the LED on shutdown/reboot/acting dead */
+	if ((system_state != MCE_STATE_ACTDEAD) &&
+	    (system_state != MCE_STATE_SHUTDOWN) &&
+	    (system_state != MCE_STATE_REBOOT)) {
+		set_led(0, 0, 0);
+	}
+	
+	if (r_sysfs)
+		free(r_sysfs);
+	if (g_sysfs)
+		free(g_sysfs);
+	if (b_sysfs)
+		free(b_sysfs);
+	if (w_sysfs)
+		free(w_sysfs);
+	if (led_patterns) {
+		for (unsigned int i = 0; i < patterns_count; ++i)
+			free(led_patterns[i].name);
+		free(led_patterns);
+	}
+}


### PR DESCRIPTION
led-sw: add generic module for notification leds via the kernel led interface, uses software control for led blinking
            intended for use where no hardware accelerated led patterns are available. 
led-dbus: implements the mce notification dbus interface, common module intended to be used by all notification led backends