### PR TITLE
Fix shutdown

### DIFF
--- a/mce.c
+++ b/mce.c
@@ -160,6 +160,7 @@ static void signal_handler(const gint signr)
 		break;
 
 	case SIGTERM:
+	case SIGINT:
 		g_main_loop_quit(mainloop);
 		break;
 
@@ -449,6 +450,7 @@ int main(int argc, char **argv)
 	signal(SIGUSR1, signal_handler);
 	signal(SIGHUP, signal_handler);
 	signal(SIGTERM, signal_handler);
+	signal(SIGINT, signal_handler);
 
 	/* Initialise GType system */
 #if !GLIB_CHECK_VERSION(2,35,0)

--- a/modules/x11-ctrl.c
+++ b/modules/x11-ctrl.c
@@ -282,5 +282,6 @@ void g_module_unload(GModule *module)
 	remove_output_trigger_from_datapipe(&display_state_pipe,
 					    display_state_trigger);
 
+	x11_set_all_input_devices_enabled(NULL, true);
 }
 


### PR DESCRIPTION
fixes mce not shuting down cleanly on SIGINT
fixes mce not reenabling the xinput devices on exit whilst the screen is off