### PR TITLE
Split modules in mce.ini into Modules, ModulesDevice and ModulesUser

### DIFF
--- a/mce-modules.h
+++ b/mce-modules.h
@@ -30,8 +30,16 @@
 /** Name of configuration key for module path */
 #define MCE_CONF_MODULES_PATH		"ModulePath"
 
-/** Name of configuration key for modules to load */
+/** Name of configuration key for general modules to load */
 #define MCE_CONF_MODULES_MODULES	"Modules"
+
+/** Name of configuration key for device specific modules to load */
+
+#define MCE_CONF_MODULES_DEVMODULES	"ModulesDevice"
+
+/** Name of configuration key for user modules to load */
+
+#define MCE_CONF_MODULES_USRMODULES	"ModulesUser"
 
 /** Default value for module path */
 #define DEFAULT_MCE_MODULE_PATH		"/usr/lib/mce/modules"

--- a/mce.ini
+++ b/mce.ini
@@ -11,10 +11,13 @@ ModulePath=/usr/lib/mce/modules
 
 # Modules
 #
-# List of modules to load
+# List of base modules to load
 # Note: the name should not include the "lib"-prefix
-Modules=display;x11-ctrl;keypad;evdevvibrator;led;battery;battery-upower;filter-brightness-als;inactivity;alarm;accelerometer;callstate;camera;homekey;audiorouting;iio-als
+Modules=lock-tklock;lock-devlock;power-dsme;display-dev;x11-ctrl;inactivity-dev;battery-upower;inactivity-inhibit;filter-brightness-als-iio
 
+# Additional Modules the user wants to load
+# Copy this key to mce.ini.d/99-user.ini and edit it there
+# ModulesUser=
 
 [HomeKey]
 


### PR DESCRIPTION
This is to avoid maintaining the Modules= line for eatch device, which is a pain.