### PR TITLE
battery-upower: extend n900 blacklists

### DIFF
--- a/src/modules/battery-upower.c
+++ b/src/modules/battery-upower.c
@@ -70,6 +70,12 @@ static const char* blacklist[] = {
 	"rx51-battery",
 	/* Nokia N900 charger device is exposed as battery by UPower */
 	"bq24150a-0",
+	/* We want isp1704 on N900 */
+	"twl4030_ac",
+	/* We want isp1704 on N900 */
+	"twl4030_usb",
+	/* Another bogus battery (maybe like rx51-battery) */
+	"bq27000-battery"
 	/* Droid4 line power device (driver doesn't send uevents) */
 	"usb",
 	/* End of list */


### PR DESCRIPTION
This allows the N900 to once again detect charging in MCE.

We need to use isp1704, not any of the twl* devices. There is no way to distinguish them by code in upower, so let's just blacklist them.

Also blacklist (yet another) dummy battery, which might just be rx51-battery under a new name. This is not strictly necessary, since it -currently- is ordered to appear after the real battery, but let's just blacklist it anyway.