### PR TITLE
fix activation of full and low battery led patterns

### DIFF
--- a/src/modules/battery-upower.c
+++ b/src/modules/battery-upower.c
@@ -269,7 +269,7 @@ mcebat_update_cb(gpointer user_data)
 		/* Battery full led pattern */
 		if (mcebat.status == BATTERY_STATUS_FULL) {
 			gchar *pattern = g_strdup(MCE_LED_PATTERN_BATTERY_FULL);
-			execute_datapipe(&led_pattern_activate_pipe, pattern, USE_CACHE, DONT_CACHE_INDATA);
+			execute_datapipe(&led_pattern_activate_pipe, pattern, USE_INDATA, DONT_CACHE_INDATA);
 			g_free(pattern);
 		}
 		else if (prev.status == BATTERY_STATUS_FULL) {
@@ -283,7 +283,7 @@ mcebat_update_cb(gpointer user_data)
 		if (mcebat.status == BATTERY_STATUS_LOW ||
 			mcebat.status == BATTERY_STATUS_EMPTY) {
 			gchar *pattern = g_strdup(MCE_LED_PATTERN_BATTERY_LOW);
-			execute_datapipe(&led_pattern_activate_pipe, pattern, USE_CACHE, DONT_CACHE_INDATA);
+			execute_datapipe(&led_pattern_activate_pipe, pattern, USE_INDATA, DONT_CACHE_INDATA);
 			g_free(pattern);
 		}
 		else {


### PR DESCRIPTION
It appears that `MCE_LED_PATTERN_BATTERY_FULL` (as well as the less-used `MCE_LED_PATTERN_BATTERY_LOW`) was broken on all devices due to this typo. On devices such as the Droid 4, the issue was hidden by the fact that it always shows a green LED when charging.