### PR TITLE
battery: optionally use capacity_level for determining battery state

### DIFF
--- a/config/mce.ini
+++ b/config/mce.ini
@@ -312,6 +312,13 @@ PatternUserManual=9;1;0;1;0;0;0;0;0
 # Percentage at wich the battery is considerd "low" and a warning appears
 LowPercentage=10
 
+# Enable this to use capacity_level from sysfs for shutdown policy
+UseCapacityLevel=false
+
+# When UseCapacityLevel = true, enable this to consider battery as empty when
+# capacity_level is "low" instead of "critical"
+CapacityLevelLowCritical=false
+
 [Display]
 
 # Time in seconds between the display going dim and it turning off entirely


### PR DESCRIPTION
Requires upower with a patch to expose capacity_level on sysfs [0]. The functionality is enabled in the config file. It is additionally possible to configure mce to consider the battery as completely empty when capacity_level reports "Low".

[0] https://gitlab.freedesktop.org/upower/upower/-/merge_requests/259